### PR TITLE
Create better placement script to assist with dynamo and energy converter placement

### DIFF
--- a/kubejs/server_scripts/better_placement.js
+++ b/kubejs/server_scripts/better_placement.js
@@ -1,0 +1,34 @@
+//Shamelessly stolen from A&B :)
+function opposite(face) {
+	if (face.equals('down'))
+		return 'up'
+	if (face.equals('east'))
+		return 'west'
+	if (face.equals('west'))
+		return 'east'
+	if (face.equals('north'))
+		return 'south'
+	if (face.equals('south'))
+		return 'north'
+	return 'down'
+}
+
+BlockEvents.placed(event => {
+	let block = event.getBlock()
+	// Reverse placed Dynamos on Sneak 
+	if (event.getEntity() == null)
+		return
+	if (block.getId().startsWith('thermal:dynamo') || (block.getId().startsWith('systeams:'))) { //systeams:steam is not a block thankfully
+		let properties = block.getProperties()
+		if (event.getEntity().isCrouching()) {
+			properties['facing'] = opposite(properties['facing'].toString())
+			block.set(block.getId(), properties)
+		}
+	}
+
+	if (block.getId().startsWith('gtceu:')) {
+		if (block.getId().endsWith('_energy_converter')) {
+			block.mergeEntityData({energyContainer: {feToEu: true}})
+		}
+	}
+})

--- a/kubejs/server_scripts/better_placement.js
+++ b/kubejs/server_scripts/better_placement.js
@@ -15,9 +15,19 @@ function opposite(face) {
 
 BlockEvents.placed(event => {
 	let block = event.getBlock()
+
+	//gtceu blocks
+	if (block.getId().startsWith('gtceu:')) {
+		//Set energy converters to feToEu mode when placed
+		if (block.getId().endsWith('_energy_converter')) {
+			block.mergeEntityData({energyContainer: {feToEu: true}})
+		}
+	}
+
+	//Blocks below these line only get their placements altered if they were placed by an entity
+	if (event.getEntity() == null) return
+
 	// Reverse placed Dynamos on Sneak 
-	if (event.getEntity() == null)
-		return
 	if (block.getId().startsWith('thermal:dynamo') || (block.getId().startsWith('systeams:'))) { //systeams:steam is not a block thankfully
 		let properties = block.getProperties()
 		if (event.getEntity().isCrouching()) {
@@ -26,9 +36,4 @@ BlockEvents.placed(event => {
 		}
 	}
 
-	if (block.getId().startsWith('gtceu:')) {
-		if (block.getId().endsWith('_energy_converter')) {
-			block.mergeEntityData({energyContainer: {feToEu: true}})
-		}
-	}
 })


### PR DESCRIPTION
Ported the dynamo placement script from A&B to work on dynamos and boilers. Placing them while sneaking will now invert the direction they are placed in.
Placed energy converters will now get set to fe->eu mode by default when placed.