### PR TITLE
add blockswap to deal with nuclearcraft ores

### DIFF
--- a/config/NuclearCraft/materials.toml
+++ b/config/NuclearCraft/materials.toml
@@ -2,17 +2,17 @@
 #Settings for ore generation
 [ores]
 	#List of dimensions to generate ores: lithium, platinum, thorium, tin, magnesium, silver, cobalt, uranium, zinc, boron, lead
-	dimensions = [[0, -4848], [0, -4848], [0, -4848], [0, -4848], [0, -4848], [0, -4848], [0, -4848], [0, -4848], [0, -4848], [0, -4848], [0, -4848]]
+	dimensions = [[42069], [42069], [42069], [42069], [42069], [42069], [42069], [42069], [42069], [42069], [42069]]
 	#Enable ore registration: lithium, platinum, thorium, tin, magnesium, silver, cobalt, uranium, zinc, boron, lead
-	register_ore = [false, false, false, false, false, false, false, false, false, false, false]
+	register_ore = [true, true, true, true, true, true, true, true, true, true, true]
 	#Ore blocks per vein. Order: lithium, platinum, thorium, tin, magnesium, silver, cobalt, uranium, zinc, boron, lead
 	vein_size = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 	#Veins in chunk. Order: lithium, platinum, thorium, tin, magnesium, silver, cobalt, uranium, zinc, boron, lead
-	veins_in_chunk = [3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3]
+	veins_in_chunk = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 	#Minimal generation height. Order: lithium, platinum, thorium, tin, magnesium, silver, cobalt, uranium, zinc, boron, lead
-	min_height = [-60, -60, -60, 4, -60, -60, -60, -60, 4, -60, 4]
+	min_height = [-420, -420, -420, -420, -420, -420, -420, -420, -420, -420, -420]
 	#Max generation height. Order: lithium, platinum, thorium, tin, magnesium, silver, cobalt, uranium, zinc, boron, lead
-	max_height = [60, 0, 60, 60, 60, 60, 60, 60, 60, 60, 60]
+	max_height = [-69, -69, -69, -69, -69, -69, -69, -69, -69, -69, -69]
 
 [slurries]
 	#List of available slurries (dissolved ores in acid)
@@ -272,5 +272,5 @@
 #Forge Tag priority
 [forge_tag_priority]
 	#Priority of mods to resolve forge tags to itemstack and fluidstack.
-	mods_priority = ["nuclearcraft", "mekanism", "immersiveengineering", "tconstruct"]
+	mods_priority = ["gtceu", "nuclearcraft"]
 

--- a/config/blockswap/block_swap.json5
+++ b/config/blockswap/block_swap.json5
@@ -1,0 +1,107 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+{
+	// Generates all block states for all blocks in the registry.
+	"generate_all_known_states": true,
+	// Whether blocks are replaced in existing chunks.
+	"retro_gen": false,
+	/* A map of states that specifies what the "old" block state is and what its "new" block state is.
+	   See "known_states" folder("generate_all_known_states" must be set to true in this config) to see all known block states available for all blocks available in the registry.
+	   Example:
+	    "state_swapper": [
+	    	{
+	    		"new": {
+	    			"Name": "minecraft:birch_log",
+	    			// Properties define the state of this block/fluid.
+	    			"Properties": {
+	    				"axis": "x"
+	    			}
+	    		},
+	    		"old": {
+	    			"Name": "minecraft:oak_log",
+	    			// Properties define the state of this block/fluid.
+	    			"Properties": {
+	    				"axis": "z"
+	    			}
+	    		}
+	    	},
+	    	{
+	    		"new": {
+	    			"Name": "minecraft:birch_leaves",
+	    			// Properties define the state of this block/fluid.
+	    			"Properties": {
+	    				"distance": "7",
+	    				"persistent": "true"
+	    			}
+	    		},
+	    		"old": {
+	    			"Name": "minecraft:acacia_log",
+	    			// Properties define the state of this block/fluid.
+	    			"Properties": {
+	    				"axis": "z"
+	    			}
+	    		}
+	    	},
+	    	{
+	    		"new": {
+	    			"Name": "minecraft:jungle_log",
+	    			// Properties define the state of this block/fluid.
+	    			"Properties": {
+	    				"axis": "x"
+	    			}
+	    		},
+	    		"old": {
+	    			"Name": "minecraft:birch_log",
+	    			// Properties define the state of this block/fluid.
+	    			"Properties": {
+	    				"axis": "z"
+	    			}
+	    		}
+	    	},
+	    	{
+	    		"new": {
+	    			"Name": "minecraft:jungle_planks",
+	    		},
+	    		"old": {
+	    			"Name": "minecraft:acacia_planks",
+	    			}
+	    		}
+	    	}
+	    ]
+	*/
+	"state_swapper": [],
+	/* A map of blocks that specifies what the "old" block is and what its "new" block is.
+	   Example:
+	   	"swapper": {
+	   		"minecraft:coarse_dirt": "minecraft:dirt",
+	   		"minecraft:diamond_block": "minecraft:emerald_block"
+	   	}
+	*/
+	"swapper": {
+		"nuclearcraft:magnesium_ore": "minecraft:stone",
+		"nuclearcraft:cobalt_ore": "minecraft:stone",
+		"nuclearcraft:lead_ore": "minecraft:stone",
+		"nuclearcraft:lithium_ore": "minecraft:stone",
+		"nuclearcraft:thorium_ore": "minecraft:stone",
+		"nuclearcraft:tin_ore": "minecraft:stone",
+		"nuclearcraft:silver_ore": "minecraft:stone",
+		"nuclearcraft:uranium_ore": "minecraft:stone",
+		"nuclearcraft:zinc_ore": "minecraft:stone",
+		"nuclearcraft:boron_ore": "minecraft:stone",
+		"nuclearcraft:magnesium_deepslate_ore": "minecraft:deepslate",
+		"nuclearcraft:cobalt_deepslate_ore": "minecraft:deepslate",
+		"nuclearcraft:lithium_deepslate_ore": "minecraft:deepslate",
+		"nuclearcraft:thorium_deepslate_ore": "minecraft:deepslate",
+		"nuclearcraft:platinum_deepslate_ore": "minecraft:deepslate",
+		"nuclearcraft:silver_deepslate_ore": "minecraft:deepslate",
+		"nuclearcraft:uranium_deepslate_ore": "minecraft:deepslate",
+		"nuclearcraft:boron_deepslate_ore": "minecraft:deepslate"
+	}
+}

--- a/config/blockswap/known_states/minecraft/deepslate.json5
+++ b/config/blockswap/known_states/minecraft/deepslate.json5
@@ -1,0 +1,28 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		// Properties define the state of this block/fluid.
+		"Properties": {
+			"axis": "x"
+		},
+		"Name": "minecraft:deepslate"
+	},
+	{
+		"Name": "minecraft:deepslate"
+	},
+	{
+		// Properties define the state of this block/fluid.
+		"Properties": {
+			"axis": "z"
+		},
+		"Name": "minecraft:deepslate"
+	}
+]

--- a/config/blockswap/known_states/minecraft/stone.json5
+++ b/config/blockswap/known_states/minecraft/stone.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "minecraft:stone"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/boron_deepslate_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/boron_deepslate_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:boron_deepslate_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/boron_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/boron_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:boron_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/cobalt_deepslate_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/cobalt_deepslate_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:cobalt_deepslate_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/cobalt_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/cobalt_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:cobalt_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/lead_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/lead_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:lead_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/lithium_deepslate_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/lithium_deepslate_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:lithium_deepslate_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/lithium_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/lithium_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:lithium_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/magnesium_deepslate_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/magnesium_deepslate_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:magnesium_deepslate_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/magnesium_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/magnesium_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:magnesium_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/platinum_deepslate_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/platinum_deepslate_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:platinum_deepslate_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/silver_deepslate_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/silver_deepslate_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:silver_deepslate_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/silver_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/silver_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:silver_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/thorium_deepslate_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/thorium_deepslate_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:thorium_deepslate_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/thorium_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/thorium_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:thorium_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/tin_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/tin_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:tin_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/uranium_deepslate_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/uranium_deepslate_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:uranium_deepslate_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/uranium_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/uranium_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:uranium_ore"
+	}
+]

--- a/config/blockswap/known_states/nuclearcraft/zinc_ore.json5
+++ b/config/blockswap/known_states/nuclearcraft/zinc_ore.json5
@@ -1,0 +1,14 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+[
+	{
+		"Name": "nuclearcraft:zinc_ore"
+	}
+]

--- a/config/blockswap/missing_block_ids.json5
+++ b/config/blockswap/missing_block_ids.json5
@@ -1,0 +1,20 @@
+/*
+This file uses the ".json5" file extension which allows for comments like this in a json file!
+Your text editor may show this file with invalid/no syntax, if so, we recommend you download:
+
+VSCode: https://code.visualstudio.com/
+JSON5 plugin(for VSCode): https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-json5
+
+to make editing this file much easier.
+*/
+{
+	/* A map of blocks that specifies what the "old" broken block is and what its "new" functional block is.
+	   Example:
+	   	"swapper": {
+	   	          Broken ID             Valid ID
+	   		"minecraft:coarse_dirt": "minecraft:dirt",
+	   		"minecraft:diamond_block": "minecraft:emerald_block"
+	   	}
+	*/
+	"id_remapper": { }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -947,6 +947,11 @@
             "projectID": 232131,
             "fileID": 4635878,
             "required": true
+        },
+        {
+            "projectID": 468893,
+            "fileID": 4598162,
+            "required": true
         }
     ],
     "overrides": "overrides"


### PR DESCRIPTION
Re-add nuclear craft ores to make the prospector work.
Add blockswap and configure it to swap out nuclearcraft ores.
Add gtceu to nuclearcraft mods priority (I have no clue what this does)