### PR TITLE
Fixed LV Circuit Assembler Dependency (Issue #108)

### DIFF
--- a/config/ftbquests/quests/chapters/early_game.snbt
+++ b/config/ftbquests/quests/chapters/early_game.snbt
@@ -1035,7 +1035,6 @@
 			dependencies: [
 				"1D95AC7CAC7D5121"
 				"3E42B4AAA6D2A05B"
-				"27913342423025C3"
 			]
 			description: [
 				"&3Circuit Assemblers&r are the linchpin of your factory, gating progression through the &6Circuits&r. "
@@ -1102,7 +1101,10 @@
 			y: 10.0d
 		}
 		{
-			dependencies: ["7AA5FD63FA3BA43C"]
+			dependencies: [
+				"7AA5FD63FA3BA43C"
+				"2DDCA4800EFB303E"
+			]
 			description: [
 				"These are easier to mass produce than &6Electronic Circuits&r, and they're required to produce the &6Advanced Integrated Circuit&r, your first &6HV&r circuit."
 				""


### PR DESCRIPTION
Should be self-explanatory - LV circuit assembler quest used to need second LV circuit quest, this inverts that. Was going to make a bigger PR but the other changes were a bit more elaborate