### PR TITLE
Reduced output-based recipe removals & recipe duplication

### DIFF
--- a/kubejs/server_scripts/Early_Game.js
+++ b/kubejs/server_scripts/Early_Game.js
@@ -7,7 +7,7 @@ ServerEvents.recipes(event => {
         .EUt(16)
 
     // May as well remove ender dust usage while we're at it
-    event.remove({ input: "miniutilities:ender_dust" })
+    event.remove({ id: "miniutilities:ender_dust_to_ender_pearl" })
 
     var plantMaterial = ["#minecraft:leaves", "#minecraft:saplings", "minecraft:vine"]
     plantMaterial.forEach(ballIngredient => {
@@ -28,7 +28,6 @@ ServerEvents.recipes(event => {
     event.shapeless("kubejs:dust", ["minecraft:sand", "#forge:tools/hammers"])
 
     // EIO Solar
-    event.remove({ output: "enderio:photovoltaic_plate" })
     event.recipes.gtceu.alloy_smelter("photovoltaic_plate")
         .itemInputs("2x enderio:photovoltaic_composite", "gtceu:electrical_steel_plate")
         .itemOutputs("enderio:photovoltaic_plate")
@@ -36,14 +35,14 @@ ServerEvents.recipes(event => {
         .EUt(16)
 
     // Solar composite
-    event.remove({ output: "enderio:photovoltaic_composite" })
+    event.remove({ id: "enderio:photovoltaic_composite" })
     event.shapeless("3x enderio:photovoltaic_composite", ["gtceu:lapis_dust", "gtceu:coal_dust", "gtceu:silicon_dust"])
 
     // Drawers
-    event.remove({ output: "storagedrawers:obsidian_storage_upgrade" })
-    event.remove({ output: "storagedrawers:compacting_drawers_3" })
-    event.remove({ output: "storagedrawers:controller" })
-    event.remove({ output: "storagedrawers:controller_slave" })
+    event.remove({ id: "storagedrawers:obsidian_storage_upgrade" })
+    event.remove({ id: "storagedrawers:compacting_drawers_3" })
+    event.remove({ id: "storagedrawers:controller" })
+    event.remove({ id: "storagedrawers:controller_slave" })
     event.shaped(
         "storagedrawers:obsidian_storage_upgrade", [
         'SSS',
@@ -125,7 +124,7 @@ ServerEvents.recipes(event => {
         .EUt(30)
 
     // Pyro Oven
-    event.remove({ output: 'gtceu:pyrolyse_oven' })
+    event.remove({ id: 'gtceu:shaped/pyrolyse_oven' })
     event.shaped(
         'gtceu:pyrolyse_oven', [
         'PCW',

--- a/kubejs/server_scripts/Early_Game.js
+++ b/kubejs/server_scripts/Early_Game.js
@@ -35,14 +35,10 @@ ServerEvents.recipes(event => {
         .EUt(16)
 
     // Solar composite
-    event.remove({ id: "enderio:photovoltaic_composite" })
-    event.shapeless("3x enderio:photovoltaic_composite", ["gtceu:lapis_dust", "gtceu:coal_dust", "gtceu:silicon_dust"])
+    event.shapeless("3x enderio:photovoltaic_composite", ["gtceu:lapis_dust", "gtceu:coal_dust", "gtceu:silicon_dust"]).id('enderio:photovoltaic_composite')
 
     // Drawers
-    event.remove({ id: "storagedrawers:obsidian_storage_upgrade" })
-    event.remove({ id: "storagedrawers:compacting_drawers_3" })
     event.remove({ id: "storagedrawers:controller" })
-    event.remove({ id: "storagedrawers:controller_slave" })
     event.shaped(
         "storagedrawers:obsidian_storage_upgrade", [
         'SSS',
@@ -53,7 +49,7 @@ ServerEvents.recipes(event => {
         C: "minecraft:coal",
         U: "storagedrawers:upgrade_template"
     }
-    )
+    ).id('storagedrawers:obsidian_storage_upgrade')
     event.shaped(
         "storagedrawers:compacting_drawers_3", [
         'III',
@@ -64,7 +60,7 @@ ServerEvents.recipes(event => {
         P: "gtceu:lv_electric_piston",
         D: "#storagedrawers:drawers"
     }
-    )
+    ).id('storagedrawers:compacting_drawers_3')
     event.shaped(
         "storagedrawers:controller_slave", [
         'III',
@@ -76,7 +72,7 @@ ServerEvents.recipes(event => {
         D: "#storagedrawers:drawers",
         G: "minecraft:gold_block"
     }
-    )
+    ).id('storagedrawers:controller_slave')
 
     var controllerCore = ["minecraft:diamond_block", "minecraft:emerald_block"]
     controllerCore.forEach(coreBlock => {
@@ -124,7 +120,6 @@ ServerEvents.recipes(event => {
         .EUt(30)
 
     // Pyro Oven
-    event.remove({ id: 'gtceu:shaped/pyrolyse_oven' })
     event.shaped(
         'gtceu:pyrolyse_oven', [
         'PCW',
@@ -137,7 +132,7 @@ ServerEvents.recipes(event => {
         W: 'gtceu:cupronickel_quadruple_wire',
         H: 'gtceu:ulv_machine_hull'
     }
-    )
+    ).id('gtceu:shaped/pyrolyse_oven')
 
     //Toolbelts
     event.replaceInput({ output: 'toolbelt:pouch' }, 'minecraft:gold_ingot', 'gtceu:steel_ingot')

--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -96,7 +96,6 @@ ServerEvents.recipes(event => {
     })
 
     // Blacklight
-    event.remove({ id: 'gtceu:shaped/blacklight' })
     event.shaped(
         'gtceu:blacklight', [
             'BPB',
@@ -109,10 +108,9 @@ ServerEvents.recipes(event => {
             S: 'gtceu:hssg_spring',
             W: 'gtceu:platinum_single_cable'
         }
-    )
+    ).id('gtceu:shaped/blacklight')
 
     // Sterilising Filter Casing
-    event.remove({ id: 'gtceu:shaped/filter_casing_sterile' })
     event.shaped(
         'gtceu:sterilizing_filter_casing', [
             'PEP',
@@ -127,7 +125,7 @@ ServerEvents.recipes(event => {
             R: 'gtceu:osmiridium_rotor', // TODO: replace with iridium rotor if possible
             S: 'gtceu:black_steel_frame'
         }
-    )
+    ).id('gtceu:shaped/filter_casing_sterile')
 
     // FLux Gem
     event.remove({ id: 'redstone_arsenal:materials/flux_gem' })
@@ -139,7 +137,6 @@ ServerEvents.recipes(event => {
         .EUt(400)
 
     // Flux Plating
-    event.remove({ id: 'redstone_arsenal:materials/flux_plating' })
     event.shaped(
         '4x redstone_arsenal:flux_plating', [
             ' P ',
@@ -149,7 +146,7 @@ ServerEvents.recipes(event => {
             G: 'redstone_arsenal:flux_gem',
             P: 'gtceu:electrum_flux_plate'
         }
-    )
+    ).id('redstone_arsenal:materials/flux_plating')
 
     // Vacuum Freezer
 

--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -96,7 +96,7 @@ ServerEvents.recipes(event => {
     })
 
     // Blacklight
-    event.remove({ output: 'gtceu:blacklight' })
+    event.remove({ id: 'gtceu:shaped/blacklight' })
     event.shaped(
         'gtceu:blacklight', [
             'BPB',
@@ -112,7 +112,7 @@ ServerEvents.recipes(event => {
     )
 
     // Sterilising Filter Casing
-    event.remove({ output: 'gtceu:sterilizing_filter_casing' })
+    event.remove({ id: 'gtceu:shaped/filter_casing_sterile' })
     event.shaped(
         'gtceu:sterilizing_filter_casing', [
             'PEP',
@@ -130,7 +130,7 @@ ServerEvents.recipes(event => {
     )
 
     // FLux Gem
-    event.remove({ output: 'redstone_arsenal:flux_gem' })
+    event.remove({ id: 'redstone_arsenal:materials/flux_gem' })
     event.recipes.gtceu.autoclave("flux_gem")
         .itemInputs('minecraft:diamond')
         .inputFluids('gtceu:redstone 720')
@@ -139,7 +139,7 @@ ServerEvents.recipes(event => {
         .EUt(400)
 
     // Flux Plating
-    event.remove({ output: 'redstone_arsenal:flux_plating' })
+    event.remove({ id: 'redstone_arsenal:materials/flux_plating' })
     event.shaped(
         '4x redstone_arsenal:flux_plating', [
             ' P ',
@@ -171,7 +171,8 @@ ServerEvents.recipes(event => {
         .EUt(2000)
 
     //Draconic Stem Cells
-    event.remove({ output: 'gtceu:stem_cells' })
+    event.remove({ id: 'gtceu:chemical_reactor/stem_cells' })
+    event.remove({ id: 'gtceu:large_chemical_reactor/stem_cells'})
     event.recipes.gtceu.chemical_reactor("draconic_stem_cells")
         .itemInputs('minecraft:dragon_egg')
         .inputFluids('gtceu:sterilized_growth_medium 500', 'gtceu:bacteria 500')

--- a/kubejs/server_scripts/End_Game.js
+++ b/kubejs/server_scripts/End_Game.js
@@ -124,7 +124,7 @@ ServerEvents.recipes(event => {
             F: 'gtceu:item_filter',
             M: 'gtceu:luv_electric_motor',
             P: 'gtceu:polybenzimidazole_large_fluid_pipe',
-            R: 'gtceu:osmiridium_rotor',
+            R: 'gtceu:osmiridium_rotor', // TODO: replace with iridium rotor if possible
             S: 'gtceu:black_steel_frame'
         }
     )

--- a/kubejs/server_scripts/Gregicality_Rocketry.js
+++ b/kubejs/server_scripts/Gregicality_Rocketry.js
@@ -129,7 +129,7 @@ ServerEvents.recipes(event => {
     )
 
     // Space Station Packager
-    event.remove({ output: "gcyr:space_station_packager" })
+    event.remove({ id: "gcyr:shaped/space_station_packager" })
     event.recipes.extendedcrafting.shaped_table(
         'gcyr:space_station_packager', [
             "RPEPR",

--- a/kubejs/server_scripts/Gregicality_Rocketry.js
+++ b/kubejs/server_scripts/Gregicality_Rocketry.js
@@ -95,7 +95,6 @@ ServerEvents.recipes(event => {
         .EUt(30)
 
     // ID Chip
-    event.remove({ id: "gcyr:shapeless/id_chip" })
     event.shaped(
         'gcyr:id_chip', [
             'VEC',
@@ -107,10 +106,9 @@ ServerEvents.recipes(event => {
             V: 'gtceu:vibrant_alloy_plate',
             P: 'gtceu:glass_plate',
             C: '#gtceu:circuits/mv'
-        })
+        }).id('gcyr:shapeless/id_chip')
 
     // Rocket Scanner
-    event.remove({ id: "gcyr:shaped/rocket_scanner" })
     event.recipes.extendedcrafting.shaped_table(
         'gcyr:rocket_scanner', [
             "RPEPR",
@@ -126,10 +124,9 @@ ServerEvents.recipes(event => {
             E: 'gtceu:hv_emitter',
             C: '#gtceu:circuits/hv'
         }, 2
-    )
+    ).id('gcyr:shaped/rocket_scanner')
 
     // Space Station Packager
-    event.remove({ id: "gcyr:shaped/space_station_packager" })
     event.recipes.extendedcrafting.shaped_table(
         'gcyr:space_station_packager', [
             "RPEPR",
@@ -145,7 +142,7 @@ ServerEvents.recipes(event => {
             E: 'gtceu:ev_emitter',
             C: '#gtceu:circuits/ev'
         }, 2
-    )
+    ).id('gcyr:shaped/space_station_packager')
 
     //Motors and Tanks
     event.shaped(

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -6,7 +6,8 @@
 ServerEvents.recipes(event => {
 
     // snad
-    event.remove({ output: ["snad:snad", "snad:red_snad"] })
+    event.remove({ id: "snad:snadrecipe" })
+    event.remove({ id: "snad:red_snad" })
     event.shapeless('snad:snad', ['kubejs:double_compressed_sand', 'kubejs:double_compressed_sand'])
     event.shapeless('snad:red_snad', ['kubejs:double_compressed_red_sand', 'kubejs:double_compressed_red_sand'])
 
@@ -136,8 +137,8 @@ ServerEvents.recipes(event => {
         .EUt(15)
 
     // Change recipes for LV and MV macerators
-    event.remove({ output: "gtceu:lv_macerator" })
-    event.remove({ output: "gtceu:mv_macerator" })
+    event.remove({ id: "gtceu:shaped/lv_macerator" })
+    event.remove({ id: "gtceu:shaped/mv_macerator" })
 
     event.shaped(
         "gtceu:lv_macerator", [
@@ -185,7 +186,7 @@ ServerEvents.recipes(event => {
     )
 
     // Make lowest tier fluid conduit pressurized
-    event.remove({ output: "enderio:fluid_conduit" })
+    event.remove({ id: "enderio:fluid_conduit" })
     event.shaped(
         "4x enderio:pressurized_fluid_conduit", [
             'BBB',
@@ -198,7 +199,6 @@ ServerEvents.recipes(event => {
     )
 
     // Steam oven & grinder
-    event.remove({ output: "gtceu:steam_oven" })
     event.shaped(
         "gtceu:steam_oven", [
             'BGB',
@@ -212,7 +212,6 @@ ServerEvents.recipes(event => {
         }
     )
 
-    event.remove({ output: "gtceu:steam_grinder" })
     event.shaped(
         "gtceu:steam_grinder", [
             'BGB',
@@ -328,7 +327,10 @@ ServerEvents.recipes(event => {
         .EUt(16)
 
     // Nomify LV motors
-    event.remove({ output: "gtceu:lv_electric_motor" })
+    event.remove({ id: "gtceu:shaped/electric_motor_lv_steel" })
+    event.remove({ id: "gtceu:shaped/electric_motor_lv_iron" })
+    event.remove({ id: "gtceu:assembler/electric_motor_lv_steel" })
+    event.remove({ id: "gtceu:assembler/electric_motor_lv_iron" })
 
     event.shaped(
         "gtceu:lv_electric_motor", [
@@ -378,7 +380,7 @@ ServerEvents.recipes(event => {
         .cleanroom(CleanroomType.CLEANROOM)
 
     // Drawer templates lower yield
-    event.remove({ output: "storagedrawers:upgrade_template" })
+    event.remove({ id: "storagedrawers:upgrade_template" })
     event.shaped(
         "2x storagedrawers:upgrade_template", [
             'SSS',
@@ -392,7 +394,7 @@ ServerEvents.recipes(event => {
 
     // NC cobble gen replaced with thermal for now, make buckets empty but indicate how it must be placed, also remove easy auto deepslate and friends
     event.remove({ type: "thermal:rock_gen", not: { output: "minecraft:cobblestone" } })
-    event.remove({ output: "thermal:device_rock_gen" })
+    event.remove({ id: "thermal:device_rock_gen" })
     event.shaped(
         "thermal:device_rock_gen", [
             'PPP',
@@ -407,7 +409,7 @@ ServerEvents.recipes(event => {
     //TODO: AE2 crystal growth accelerator goes here
 
     // Nomified distill tower
-    event.remove({ output: "gtceu:distillation_tower" })
+    event.remove({ id: "gtceu:shaped/distillation_tower" })
     event.shaped(
         "gtceu:distillation_tower", [
             'LPL',
@@ -422,7 +424,7 @@ ServerEvents.recipes(event => {
     )
 
     // Implement draconium smelting
-    event.remove({ output: "gtceu:draconium_hot_ingot" })
+    event.remove({ id: "gtceu:electric_blast_furnace/blast_draconium" })
 
     var draconiumFuels = [
         [2000, "gtceu:cetane_boosted_diesel"],
@@ -530,7 +532,7 @@ ServerEvents.recipes(event => {
         .EUt(7680)
 
     // Ass control casing
-    event.remove({ output: "gtceu:assembly_line_unit" })
+    event.remove({ id: "gtceu:shaped/casing_assembly_line" })
     event.shaped(
         "4x gtceu:assembly_line_unit", [
             'CHC',

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -474,39 +474,6 @@ ServerEvents.recipes(event => {
         }
     )
 
-    // Blacklight & sterile filter
-    event.remove({ output: "gtceu:blacklight" })
-    event.shaped(
-        "gtceu:blacklight", [
-            'SPS',
-            ' H ',
-            'CPW'
-        ], {
-            S: "gtceu:tungsten_carbide_screw",
-            P: "gtceu:tungsten_carbide_plate",
-            H: "gtceu:hssg_spring",
-            C: "#gtceu:circuits/iv",
-            W: "gtceu:platinum_single_cable"
-        }
-    )
-
-    event.remove({ output: "gtceu:sterilizing_filter_casing" })
-    event.shaped(
-        "gtceu:sterilizing_filter_casing", [
-            'PEP',
-            'FBF',
-            'MSR'
-        ], {
-            P: "gtceu:polybenzimidazole_large_fluid_pipe",
-            E: "gtceu:luv_emitter",
-            F: "gtceu:item_filter",
-            B: "gtceu:blacklight",
-            M: "gtceu:luv_electric_motor",
-            S: "gtceu:black_steel_frame",
-            R: "gtceu:osmiridium_rotor" //  TODO: replace with iridium
-        }
-    )
-
     // Prevent cleanroom casings from being usable for free resources
     event.remove({ input: "gtceu:sterilizing_filter_casing" })
     event.recipes.gtceu.arc_furnace("sterile_filter_recycling")

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -6,10 +6,8 @@
 ServerEvents.recipes(event => {
 
     // snad
-    event.remove({ id: "snad:snadrecipe" })
-    event.remove({ id: "snad:red_snad" })
-    event.shapeless('snad:snad', ['kubejs:double_compressed_sand', 'kubejs:double_compressed_sand'])
-    event.shapeless('snad:red_snad', ['kubejs:double_compressed_red_sand', 'kubejs:double_compressed_red_sand'])
+    event.shapeless('snad:snad', ['kubejs:double_compressed_sand', 'kubejs:double_compressed_sand']).id('snad:snadrecipe')
+    event.shapeless('snad:red_snad', ['kubejs:double_compressed_red_sand', 'kubejs:double_compressed_red_sand']).id('snad:red_snad')
 
     // snaded sand snad
     event.shaped("kubejs:compressed_sand", [
@@ -137,9 +135,6 @@ ServerEvents.recipes(event => {
         .EUt(15)
 
     // Change recipes for LV and MV macerators
-    event.remove({ id: "gtceu:shaped/lv_macerator" })
-    event.remove({ id: "gtceu:shaped/mv_macerator" })
-
     event.shaped(
         "gtceu:lv_macerator", [
             'PMB',
@@ -153,7 +148,7 @@ ServerEvents.recipes(event => {
             H: "gtceu:lv_machine_hull",
             C: "#gtceu:circuits/lv"
         }
-    )
+    ).id('gtceu:shaped/lv_macerator')
 
     event.shaped(
         "gtceu:mv_macerator", [
@@ -168,7 +163,7 @@ ServerEvents.recipes(event => {
             H: "gtceu:mv_machine_hull",
             C: "#gtceu:circuits/mv"
         }
-    )
+    ).id('gtceu:shaped/mv_macerator')
 
     // Alternative LV piston recipe
     event.shaped(
@@ -394,7 +389,6 @@ ServerEvents.recipes(event => {
 
     // NC cobble gen replaced with thermal for now, make buckets empty but indicate how it must be placed, also remove easy auto deepslate and friends
     event.remove({ type: "thermal:rock_gen", not: { output: "minecraft:cobblestone" } })
-    event.remove({ id: "thermal:device_rock_gen" })
     event.shaped(
         "thermal:device_rock_gen", [
             'PPP',
@@ -404,12 +398,11 @@ ServerEvents.recipes(event => {
             P: "gtceu:steel_plate",
             B: "minecraft:bucket"
         }
-    )
+    ).id('thermal:device_rock_gen')
 
     //TODO: AE2 crystal growth accelerator goes here
 
     // Nomified distill tower
-    event.remove({ id: "gtceu:shaped/distillation_tower" })
     event.shaped(
         "gtceu:distillation_tower", [
             'LPL',
@@ -421,7 +414,7 @@ ServerEvents.recipes(event => {
             C: "#gtceu:circuits/hv",
             H: "gtceu:hv_machine_hull"
         }
-    )
+    ).id('gtceu:shaped/distillation_tower')
 
     // Implement draconium smelting
     event.remove({ id: "gtceu:electric_blast_furnace/blast_draconium" })
@@ -499,7 +492,6 @@ ServerEvents.recipes(event => {
         .EUt(7680)
 
     // Ass control casing
-    event.remove({ id: "gtceu:shaped/casing_assembly_line" })
     event.shaped(
         "4x gtceu:assembly_line_unit", [
             'CHC',
@@ -513,7 +505,7 @@ ServerEvents.recipes(event => {
             E: "gtceu:iv_emitter",
             M: "gtceu:iv_electric_motor"
         }
-    )
+    ).id('gtceu:shaped/casing_assembly_line')
 
     // Mixer naquadah enrichment
     event.recipes.gtceu.mixer("mixer_enriched_naquadah")


### PR DESCRIPTION
Replaced output-based recipe removals from Early_Game, End_Game, random_recipes and Gregicality_Rocketry with id-based ones to improve optimisation. There's still a bunch, especially in Remove_Recipes, but I've stuck to these for the time being. It still should be a large improvement.

Also, in my infinite genius, I realised I accidentally duplicated a couple of already existing recipes. I deleted the originals instead of the duplicates because they used output-based removal and they were in the already-quite-large random_recipes file.