### PR TITLE
Uncapitalize jetpack IDs

### DIFF
--- a/config/ftbquests/quests/chapters/early_game.snbt
+++ b/config/ftbquests/quests/chapters/early_game.snbt
@@ -2499,7 +2499,7 @@
 					Count: 1b
 					id: "ironjetpacks:jetpack"
 					tag: {
-						Id: "ironjetpacks:Energetic"
+						Id: "ironjetpacks:energetic"
 						Throttle: 1.0d
 					}
 				}

--- a/config/ftbquests/quests/chapters/genesis.snbt
+++ b/config/ftbquests/quests/chapters/genesis.snbt
@@ -1655,7 +1655,7 @@
 					Count: 1b
 					id: "ironjetpacks:jetpack"
 					tag: {
-						Id: "ironjetpacks:Leadstone"
+						Id: "ironjetpacks:leadstone"
 						Throttle: 1.0d
 					}
 				}

--- a/config/ftbquests/quests/chapters/mid_game.snbt
+++ b/config/ftbquests/quests/chapters/mid_game.snbt
@@ -2567,7 +2567,7 @@
 					Count: 1b
 					id: "ironjetpacks:jetpack"
 					tag: {
-						Id: "ironjetpacks:Vibrant"
+						Id: "ironjetpacks:vibrant"
 						Throttle: 1.0d
 					}
 				}

--- a/config/ftbquests/quests/chapters/the_beginning.snbt
+++ b/config/ftbquests/quests/chapters/the_beginning.snbt
@@ -999,7 +999,7 @@
 					Count: 1b
 					id: "ironjetpacks:jetpack"
 					tag: {
-						Id: "ironjetpacks:Hardened"
+						Id: "ironjetpacks:hardened"
 						Throttle: 1.0d
 					}
 				}
@@ -1027,7 +1027,7 @@
 					Count: 1b
 					id: "ironjetpacks:jetpack"
 					tag: {
-						Id: "ironjetpacks:Reinforced"
+						Id: "ironjetpacks:reinforced"
 						Throttle: 1.0d
 					}
 				}

--- a/config/ironjetpacks/jetpacks/energetic.json
+++ b/config/ironjetpacks/jetpacks/energetic.json
@@ -1,5 +1,5 @@
 {
-    "name": "Energetic",
+    "name": "energetic",
     "disable": false,
     "tier": 3,
     "color": "00FFFFFF",

--- a/config/ironjetpacks/jetpacks/fluxed.json
+++ b/config/ironjetpacks/jetpacks/fluxed.json
@@ -1,5 +1,5 @@
 {
-    "name": "Fluxed",
+    "name": "fluxed",
     "disable": false,
     "tier": 5,
     "color": "00FFFFFF",

--- a/config/ironjetpacks/jetpacks/hardened.json
+++ b/config/ironjetpacks/jetpacks/hardened.json
@@ -1,5 +1,5 @@
 {
-    "name": "Hardened",
+    "name": "hardened",
     "disable": false,
     "tier": 2,
     "color": "00FFFFFF",

--- a/config/ironjetpacks/jetpacks/leadstone.json
+++ b/config/ironjetpacks/jetpacks/leadstone.json
@@ -1,5 +1,5 @@
 {
-    "name": "Leadstone",
+    "name": "leadstone",
     "disable": false,
     "tier": 1,
     "color": "00FFFFFF",

--- a/config/ironjetpacks/jetpacks/reinforced.json
+++ b/config/ironjetpacks/jetpacks/reinforced.json
@@ -1,5 +1,5 @@
 {
-    "name": "Reinforced",
+    "name": "reinforced",
     "disable": false,
     "tier": 3,
     "color": "00FFFFFF",

--- a/config/ironjetpacks/jetpacks/resonant.json
+++ b/config/ironjetpacks/jetpacks/resonant.json
@@ -1,5 +1,5 @@
 {
-    "name": "Resonant",
+    "name": "resonant",
     "disable": false,
     "tier": 4,
     "color": "00FFFFFF",

--- a/config/ironjetpacks/jetpacks/vibrant.json
+++ b/config/ironjetpacks/jetpacks/vibrant.json
@@ -1,5 +1,5 @@
 {
-    "name": "Vibrant",
+    "name": "vibrant",
     "disable": false,
     "tier": 4,
     "color": "00FFFFFF",

--- a/kubejs/assets/minecraft/citresewn/cit/Capacitors/energetic.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Capacitors/energetic.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:cell
 texture=jetpack_energetic
-nbt.Id=ironjetpacks:Energetic
+nbt.Id=ironjetpacks:energetic

--- a/kubejs/assets/minecraft/citresewn/cit/Capacitors/fluxed.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Capacitors/fluxed.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:cell
 texture=jetpack_fluxed
-nbt.Id=ironjetpacks:Fluxed
+nbt.Id=ironjetpacks:fluxed

--- a/kubejs/assets/minecraft/citresewn/cit/Capacitors/hardened.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Capacitors/hardened.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:cell
 texture=jetpack_hardened
-nbt.Id=ironjetpacks:Hardened
+nbt.Id=ironjetpacks:hardened

--- a/kubejs/assets/minecraft/citresewn/cit/Capacitors/lead.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Capacitors/lead.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:cell
 texture=jetpack_leadstone
-nbt.Id=ironjetpacks:Leadstone
+nbt.Id=ironjetpacks:leadstone

--- a/kubejs/assets/minecraft/citresewn/cit/Capacitors/reinforced.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Capacitors/reinforced.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:cell
 texture=jetpack_reinforced
-nbt.Id=ironjetpacks:Reinforced
+nbt.Id=ironjetpacks:reinforced

--- a/kubejs/assets/minecraft/citresewn/cit/Capacitors/resonant.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Capacitors/resonant.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:cell
 texture=jetpack_resonant
-nbt.Id=ironjetpacks:Resonant
+nbt.Id=ironjetpacks:resonant

--- a/kubejs/assets/minecraft/citresewn/cit/Capacitors/vibrant.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Capacitors/vibrant.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:cell
 texture=jetpack_vibrant
-nbt.Id=ironjetpacks:Vibrant
+nbt.Id=ironjetpacks:vibrant

--- a/kubejs/assets/minecraft/citresewn/cit/Jetpacks/energetic.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Jetpacks/energetic.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:jetpack
 texture=jetpack_energetic
-nbt.Id=ironjetpacks:Energetic
+nbt.Id=ironjetpacks:energetic

--- a/kubejs/assets/minecraft/citresewn/cit/Jetpacks/fluxed.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Jetpacks/fluxed.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:jetpack
 texture=jetpack_fluxed
-nbt.Id=ironjetpacks:Fluxed
+nbt.Id=ironjetpacks:fluxed

--- a/kubejs/assets/minecraft/citresewn/cit/Jetpacks/hardened.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Jetpacks/hardened.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:jetpack
 texture=jetpack_hardened
-nbt.Id=ironjetpacks:Hardened
+nbt.Id=ironjetpacks:hardened

--- a/kubejs/assets/minecraft/citresewn/cit/Jetpacks/lead.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Jetpacks/lead.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:jetpack
 texture=jetpack_lead
-nbt.Id=ironjetpacks:Leadstone
+nbt.Id=ironjetpacks:leadstone

--- a/kubejs/assets/minecraft/citresewn/cit/Jetpacks/reinforced.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Jetpacks/reinforced.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:jetpack
 texture=jetpack_reinforced
-nbt.Id=ironjetpacks:Reinforced
+nbt.Id=ironjetpacks:reinforced

--- a/kubejs/assets/minecraft/citresewn/cit/Jetpacks/resonant.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Jetpacks/resonant.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:jetpack
 texture=jetpack_resonant
-nbt.Id=ironjetpacks:Resonant
+nbt.Id=ironjetpacks:resonant

--- a/kubejs/assets/minecraft/citresewn/cit/Jetpacks/vibrant.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Jetpacks/vibrant.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:jetpack
 texture=jetpack_vibrant
-nbt.Id=ironjetpacks:Vibrant
+nbt.Id=ironjetpacks:vibrant

--- a/kubejs/assets/minecraft/citresewn/cit/Thrusters/energetic.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Thrusters/energetic.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:thruster
 texture=jetpack_energetic
-nbt.Id=ironjetpacks:Energetic
+nbt.Id=ironjetpacks:energetic

--- a/kubejs/assets/minecraft/citresewn/cit/Thrusters/fluxed.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Thrusters/fluxed.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:thruster
 texture=jetpack_fluxed
-nbt.Id=ironjetpacks:Fluxed
+nbt.Id=ironjetpacks:fluxed

--- a/kubejs/assets/minecraft/citresewn/cit/Thrusters/hardened.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Thrusters/hardened.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:thruster
 texture=jetpack_hardened
-nbt.Id=ironjetpacks:Hardened
+nbt.Id=ironjetpacks:hardened

--- a/kubejs/assets/minecraft/citresewn/cit/Thrusters/lead.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Thrusters/lead.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:thruster
 texture=jetpack_lead
-nbt.Id=ironjetpacks:Leadstone
+nbt.Id=ironjetpacks:leadstone

--- a/kubejs/assets/minecraft/citresewn/cit/Thrusters/reinforced.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Thrusters/reinforced.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:thruster
 texture=jetpack_reinforced
-nbt.Id=ironjetpacks:Reinforced
+nbt.Id=ironjetpacks:reinforced

--- a/kubejs/assets/minecraft/citresewn/cit/Thrusters/resonant.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Thrusters/resonant.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:thruster
 texture=jetpack_resonant
-nbt.Id=ironjetpacks:Resonant
+nbt.Id=ironjetpacks:resonant

--- a/kubejs/assets/minecraft/citresewn/cit/Thrusters/vibrant.properties
+++ b/kubejs/assets/minecraft/citresewn/cit/Thrusters/vibrant.properties
@@ -1,4 +1,4 @@
 type=item
 items=ironjetpacks:thruster
 texture=jetpack_vibrant
-nbt.Id=ironjetpacks:Vibrant
+nbt.Id=ironjetpacks:vibrant

--- a/kubejs/client_scripts/JEI.js
+++ b/kubejs/client_scripts/JEI.js
@@ -40,7 +40,7 @@ REIEvents.hide('item', event => {
     event.hide(['telepastries:lost_city_cake', 'telepastries:custom_cake2', 'telepastries:custom_cake3', 'telepastries:twilight_cake'])
 
     //Jetpacks
-    event.hide([Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:dark_soularium"}').strongNBT(), Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:Fluxed"}').strongNBT(), 'ironjetpacks:capacitor', Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:creative"}').strongNBT()])
+    event.hide([Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:dark_soularium"}').strongNBT(), Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:fluxed"}').strongNBT(), 'ironjetpacks:capacitor', Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:creative"}').strongNBT()])
     event.hide(['ironjetpacks:basic_coil', 'ironjetpacks:advanced_coil', 'ironjetpacks:elite_coil', 'ironjetpacks:ultimate_coil'])
 
     event.hide([/antiblocksrechiseled:.*?pressure_plate\S*/g, /antiblocksrechiseled:.*?button\S*/g, /antiblocksrechiseled:.*?stair\S*/g, /antiblocksrechiseled:.*?slab\S*/g, /antiblocksrechiseled:.*?border\b/g, /antiblocksrechiseled:.*?wool\S*/g])

--- a/kubejs/server_scripts/Extended_Crafting_Recipes.js
+++ b/kubejs/server_scripts/Extended_Crafting_Recipes.js
@@ -151,13 +151,13 @@ ServerEvents.recipes(event => {
                 "type": "forge:nbt",
                 "item": "ironjetpacks:jetpack",
                 "count": 1,
-                "nbt": "{Id:\"ironjetpacks:Reinforced\",Throttle:1.0d}"
+                "nbt": "{Id:\"ironjetpacks:reinforced\",Throttle:1.0d}"
             },
             "C": {
                 "type": "forge:nbt",
                 "item": "ironjetpacks:jetpack",
                 "count": 1,
-                "nbt": "{Id:\"ironjetpacks:Vibrant\",Throttle:1.0d}"
+                "nbt": "{Id:\"ironjetpacks:vibrant\",Throttle:1.0d}"
             }
         },
         "result": {

--- a/kubejs/server_scripts/Gregicality_Rocketry.js
+++ b/kubejs/server_scripts/Gregicality_Rocketry.js
@@ -175,7 +175,7 @@ ServerEvents.recipes(event => {
                 'TTT'
             ], {
                 P: 'gtceu:double_tungsten_carbide_plate',
-                T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:Energetic"}').strongNBT()
+                T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:energetic"}').strongNBT()
             })
     
         event.shaped(

--- a/kubejs/server_scripts/Iron_Jetpacks.js
+++ b/kubejs/server_scripts/Iron_Jetpacks.js
@@ -7,10 +7,10 @@ ServerEvents.recipes(event => {
 
     // Generate thermal thruster recipes
     var thermalType = [
-        ['Leadstone', 'lead', 'lead', 'thermal:dynamo_stirling'],
-        ['Hardened', 'invar', 'invar', 'thermal:dynamo_magmatic'],
-        ['Reinforced', 'aluminium', 'electrum', 'kubejs:reactant_dynamo'],
-        ['Resonant', 'enderium', 'enderium', 'thermal:dynamo_numismatic']
+        ['leadstone', 'lead', 'lead', 'thermal:dynamo_stirling'],
+        ['hardened', 'invar', 'invar', 'thermal:dynamo_magmatic'],
+        ['reinforced', 'aluminium', 'electrum', 'kubejs:reactant_dynamo'],
+        ['resonant', 'enderium', 'enderium', 'thermal:dynamo_numismatic']
     ]
 
     thermalType.forEach(material => {
@@ -31,8 +31,8 @@ ServerEvents.recipes(event => {
     var EIOType = [
         ['conductive_iron', 'conductive_alloy', 'conductive', 'kubejs:resonating_crystal', 'gtceu:red_alloy_plate'],
         ['electrical_steel', 'electrical_steel', 'conductive', 'enderio:pulsating_crystal', Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:conductive_iron"}').strongNBT()],
-        ['Energetic', 'energetic_alloy', 'energetic', 'enderio:vibrant_crystal', Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:electrical_steel"}').strongNBT()],
-        ['Vibrant', 'vibrant_alloy', 'vibrant', 'enderio:prescient_crystal', Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:Energetic"}').strongNBT()]
+        ['energetic', 'energetic_alloy', 'energetic', 'enderio:vibrant_crystal', Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:electrical_steel"}').strongNBT()],
+        ['vibrant', 'vibrant_alloy', 'vibrant', 'enderio:prescient_crystal', Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:energetic"}').strongNBT()]
     ]
 
     EIOType.forEach(material => {
@@ -60,11 +60,11 @@ ServerEvents.recipes(event => {
         I: 'gtceu:dark_soularium_ingot',
         C: 'enderio:draconium_conduit',
         F: 'kubejs:flight_control_unit',
-        T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:Vibrant"}').strongNBT()
+        T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:vibrant"}').strongNBT()
     })
 
     // Fluxed
-    event.shaped(Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:Fluxed"}'), [
+    event.shaped(Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:fluxed"}'), [
         ' P ',
         'PGP',
         'STS'
@@ -72,7 +72,7 @@ ServerEvents.recipes(event => {
         P: 'redstone_arsenal:flux_plating',
         G: 'kubejs:glowstone_elevation_unit',
         S: 'gtceu:signalum_plate',
-        T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:Resonant"}').strongNBT()
+        T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:resonant"}').strongNBT()
     })
 
     //
@@ -80,14 +80,14 @@ ServerEvents.recipes(event => {
     //
 
     var jetpackRecipe = [
-        ['Leadstone', 'ironjetpacks:strap', 'lead', Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:Leadstone"}').strongNBT()],
-        ['Hardened', Item.of('ironjetpacks:jetpack', '{Id:"ironjetpacks:Leadstone"}').strongNBT(), 'invar', Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:Hardened"}').strongNBT()],
-        ['Reinforced', Item.of('ironjetpacks:jetpack', '{Id:"ironjetpacks:Hardened"}').strongNBT(), 'electrum', Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:Reinforced"}').strongNBT()],
-        ['Resonant', Item.of('ironjetpacks:jetpack', '{Id:"ironjetpacks:Reinforced"}').strongNBT(), 'enderium', Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:Resonant"}').strongNBT()],
+        ['leadstone', 'ironjetpacks:strap', 'lead', Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:leadstone"}').strongNBT()],
+        ['hardened', Item.of('ironjetpacks:jetpack', '{Id:"ironjetpacks:leadstone"}').strongNBT(), 'invar', Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:hardened"}').strongNBT()],
+        ['reinforced', Item.of('ironjetpacks:jetpack', '{Id:"ironjetpacks:hardened"}').strongNBT(), 'electrum', Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:reinforced"}').strongNBT()],
+        ['resonant', Item.of('ironjetpacks:jetpack', '{Id:"ironjetpacks:reinforced"}').strongNBT(), 'enderium', Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:resonant"}').strongNBT()],
         ['conductive_iron', 'ironjetpacks:strap', 'conductive_alloy', 'enderio:basic_capacitor'],
         ['electrical_steel', Item.of('ironjetpacks:jetpack', '{Id:"ironjetpacks:conductive_iron"}').strongNBT(), 'electrical_steel', 'enderio:double_layer_capacitor'],
-        ['Energetic', Item.of('ironjetpacks:jetpack', '{Id:"ironjetpacks:electrical_steel"}').strongNBT(), 'energetic_alloy', 'enderio:octadic_capacitor'],
-        ['Vibrant', Item.of('ironjetpacks:jetpack', '{Id:"ironjetpacks:Energetic"}').strongNBT(), 'vibrant_alloy', 'kubejs:compressed_octadic_capacitor']
+        ['energetic', Item.of('ironjetpacks:jetpack', '{Id:"ironjetpacks:electrical_steel"}').strongNBT(), 'energetic_alloy', 'enderio:octadic_capacitor'],
+        ['vibrant', Item.of('ironjetpacks:jetpack', '{Id:"ironjetpacks:energetic"}').strongNBT(), 'vibrant_alloy', 'kubejs:compressed_octadic_capacitor']
     ]
 
     jetpackRecipe.forEach(material => {
@@ -126,7 +126,7 @@ ServerEvents.recipes(event => {
 
 
     //Cells
-    event.shaped(Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:Leadstone"}').strongNBT(), [
+    event.shaped(Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:leadstone"}').strongNBT(), [
         ' A ',
         'BCB',
         'ADA'
@@ -137,36 +137,36 @@ ServerEvents.recipes(event => {
         D: 'gtceu:sulfur_dust'
     })
 
-    event.shaped(Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:Hardened"}').strongNBT(), [
+    event.shaped(Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:hardened"}').strongNBT(), [
         ' A ',
         'BCB',
         'ADA'
     ], {
         A: 'minecraft:redstone',
         B: 'gtceu:invar_ingot',
-        C: Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:Leadstone"}').strongNBT(),
+        C: Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:leadstone"}').strongNBT(),
         D: 'gtceu:tin_ingot'
     })
 
-    event.shaped(Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:Reinforced"}').strongNBT(), [
+    event.shaped(Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:reinforced"}').strongNBT(), [
         ' A ',
         'BCB',
         'ADA'
     ], {
         A: 'minecraft:redstone',
         B: 'gtceu:electrum_ingot',
-        C: Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:Hardened"}').strongNBT(),
+        C: Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:hardened"}').strongNBT(),
         D: '#enderio:fused_quartz'
     })
 
-    event.shaped(Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:Resonant"}').strongNBT(), [
+    event.shaped(Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:resonant"}').strongNBT(), [
         ' A ',
         'BCB',
         'ADA'
     ], {
         A: 'minecraft:redstone',
         B: 'gtceu:enderium_ingot',
-        C: Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:Reinforced"}').strongNBT(),
+        C: Item.of('ironjetpacks:cell', '{Id:"ironjetpacks:reinforced"}').strongNBT(),
         D: 'kubejs:pyrotheum_dust'
     })
 })

--- a/kubejs/server_scripts/microverse.js
+++ b/kubejs/server_scripts/microverse.js
@@ -62,7 +62,7 @@ ServerEvents.recipes(event => {
             L: 'kubejs:reinforced_mining_laser',
             F: 'kubejs:electrum_micro_miner_core',
             C: 'gtceu:hv_combustion',
-            T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:Reinforced"}').strongNBT()
+            T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:reinforced"}').strongNBT()
         }, 3
     )
 
@@ -85,7 +85,7 @@ ServerEvents.recipes(event => {
             A: 'gtceu:tungsten_steel_crate',
             B: 'gtceu:hv_field_generator',
             F: 'kubejs:signalum_micro_miner_core',
-            T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:Energetic"}').strongNBT(),
+            T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:energetic"}').strongNBT(),
             D: 'thermal:dynamo_magmatic' // TODO: replace with reactant dynamo when possible
         }, 3
     )
@@ -110,7 +110,7 @@ ServerEvents.recipes(event => {
             F: 'kubejs:signalum_micro_miner_core',
             C: 'nuclearcraft:fission_reactor_controller', // TODO: REPLACE WITH REAL NC COMPONENT
             P: 'nuclearcraft:fission_reactor_port', // TODO: REPLACE WITH REAL NC COMPONENT
-            T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:Vibrant"}').strongNBT()
+            T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:vibrant"}').strongNBT()
         }, 3
     )
 
@@ -133,7 +133,7 @@ ServerEvents.recipes(event => {
             B: 'gtceu:iv_field_generator',
             C: 'nuclearcraft:fission_reactor_controller',
             P: 'nuclearcraft:fission_reactor_port',
-            T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:Resonant"}').strongNBT()
+            T: Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:resonant"}').strongNBT()
         }, 3
     )
 
@@ -305,7 +305,7 @@ ServerEvents.recipes(event => {
             'minecraft:bedrock', /* DE Magnet */
             '2x avaritia:crystal_matrix_ingot', /* TODO: replace with plate */
             '2x gtceu:iv_field_generator',
-            Item.of('2x ironjetpacks:thruster', '{Id:"ironjetpacks:Fluxed"}').strongNBT(),
+            Item.of('2x ironjetpacks:thruster', '{Id:"ironjetpacks:fluxed"}').strongNBT(),
             Item.of('ironjetpacks:thruster', '{Id:"ironjetpacks:dark_soularium"}').strongNBT())
         .itemOutputs('kubejs:warp_engine')
         .inputFluids('gtceu:soldering_alloy 1152')


### PR DESCRIPTION
Namespaced IDs are not supposed to have uppercase letters. Dedicated server can't load jetpack configs with the current IDs.
```
[main/ERROR] [Iron Jetpacks/]: An error occurred while reading jetpack json hardened.json
net.minecraft.ResourceLocationException: Non [a-z0-9/._-] character in path of location: ironjetpacks:Hardened
        at net.minecraft.resources.ResourceLocation.m_245185_(ResourceLocation.java:236) ~[server-1.20.1-20230612.114412-srg.jar%23491!/:?]
        at net.minecraft.resources.ResourceLocation.<init>(ResourceLocation.java:38) ~[server-1.20.1-20230612.114412-srg.jar%23491!/:?]
        at com.blakebr0.ironjetpacks.registry.Jetpack.<init>(Jetpack.java:61) ~[IronJetpacks-1.20.1-7.0.3.jar%23396!/:7.0.3]
        at com.blakebr0.ironjetpacks.registry.Jetpack.fromJson(Jetpack.java:221) ~[IronJetpacks-1.20.1-7.0.3.jar%23396!/:7.0.3]
        at com.blakebr0.ironjetpacks.registry.JetpackRegistry.loadFiles(JetpackRegistry.java:204) ~[IronJetpacks-1.20.1-7.0.3.jar%23396!/:7.0.3]
        at com.blakebr0.ironjetpacks.registry.JetpackRegistry.loadJetpacks(JetpackRegistry.java:167) ~[IronJetpacks-1.20.1-7.0.3.jar%23396!/:7.0.3]
        at com.blakebr0.ironjetpacks.crafting.DynamicRecipeManager.onRecipeManagerLoading(DynamicRecipeManager.java:27) ~[IronJetpacks-1.20.1-7.0.3.jar%23396!/:7.0.3]
        at com.blakebr0.ironjetpacks.crafting.__DynamicRecipeManager_onRecipeManagerLoading_RecipeManagerLoadingEvent.invoke(.dynamic) ~[IronJetpacks-1.20.1-7.0.3.jar%23396!/:7.0.3]
```

Note: this might turn jetpacks in existing saves into undefined.