### PR TITLE
Disable hud_batching because it makes gregtech durability bars invisible

### DIFF
--- a/config/immediatelyfast.json
+++ b/config/immediatelyfast.json
@@ -1,0 +1,22 @@
+{
+  "REGULAR_INFO": "----- Regular config values below -----",
+  "font_atlas_resizing": true,
+  "map_atlas_generation": true,
+  "hud_batching": false,
+  "fast_text_lookup": true,
+  "fast_buffer_upload": true,
+  "fast_buffer_upload_size_mb": 256,
+  "fast_buffer_upload_explicit_flush": true,
+  "COSMETIC_INFO": "----- Cosmetic only config values below (Does not optimize anything) -----",
+  "dont_add_info_into_debug_hud": false,
+  "EXPERIMENTAL_INFO": "----- Experimental config values below (Rendering glitches may occur) -----",
+  "experimental_disable_error_checking": false,
+  "experimental_disable_resource_pack_conflict_handling": false,
+  "experimental_sign_text_buffering": false,
+  "experimental_screen_batching": false,
+  "DEBUG_INFO": "----- Debug only config values below (Do not touch) -----",
+  "debug_only_and_not_recommended_disable_universal_batching": false,
+  "debug_only_and_not_recommended_disable_mod_conflict_handling": false,
+  "debug_only_and_not_recommended_disable_hardware_conflict_handling": false,
+  "debug_only_print_additional_error_information": false
+}


### PR DESCRIPTION
Disable hud_batching in the immediatelyfast config because it messes up gregtech durability bars

Probably a useful optimization but it makes gregtech durability bars disappear