### PR TITLE
Toolbelt Key Fix (Fixes Issue #150)

### DIFF
--- a/defaultconfigs/toolbelt-server.toml
+++ b/defaultconfigs/toolbelt-server.toml
@@ -1,0 +1,7 @@
+
+[general]
+	#List of items to force-allow placing in the belt. Takes precedence over blacklist.
+	whitelist = ['storagedrawers:drawer_key', 'storagedrawers:quantify_key', 'storagedrawers:shroud_key']
+	#List of items to disallow from placing in the belt. (whitelist takes precedence)
+	blacklist = []
+


### PR DESCRIPTION
Storage drawer keys couldn't be placed in a tool belt. This fix changes the default server config so they can, but the config will have to be copied over to the config folder of existing worlds.

The Toolbelt quest mentions disabling Satchels from being placed in there - I haven't done this, because I'm not sure if it was a bug thing or a balance thing, and if it should be extended to Sophisticated Backpacks. I didn't find any bugs from item-filled backpacks/satchels into toolbelts, but I'm not actually familiar with these kind of backpack issues, so I wouldn't know how to test for them.