### PR TITLE
Misc changes to quest book chapters

### DIFF
--- a/config/ftbquests/quests/chapters/fun_with_fusion.snbt
+++ b/config/ftbquests/quests/chapters/fun_with_fusion.snbt
@@ -10,7 +10,10 @@
 	quest_links: [ ]
 	quests: [
 		{
-			dependencies: ["15FAEE3F625265F4"]
+			dependencies: [
+				"28CA4E5308EC0BB9"
+				"0508D3CCB6C876A3"
+			]
 			description: [
 				"&2A strong heavy element obtained from the Naquadah chain."
 				""
@@ -30,48 +33,40 @@
 			y: -3.5d
 		}
 		{
-			dependencies: ["57627DCF9F46A8E2"]
-			description: [
-				"The &3Fusion Reactor&r is a multiblock that uses enormous amounts of energy to fuse fluids into new elements. This one is less flexible than the previous GregTech multiblocks, as you can only put hatches where the preview shows. &6Sneak-right click&r the controller to enable the in-world preview."
-				""
-				"The &bJEI&r preview shows &e&eall valid hatch locations&r, but you don't actually need that many fluid hatches. You can replace any of the hatch positions in the structure with &2Fusion Glass or Fusion Machine Casings&r as long as you have at least &atwo Fluid Input Hatches&r and &aone Fluid Output Hatch&r. It's possible to use input/output hatches in every valid location, if you prefer."
-			]
-			id: "70EFDBB0FFC9B28D"
-			rewards: [{
-				id: "3274F49718960647"
-				item: "kubejs:nomi_dollar"
-				type: "item"
-			}]
-			subtitle: "Time to get fusing!"
-			tasks: [{
-				id: "28F27BBFA5273F78"
-				item: "gtceu:luv_fusion_reactor"
-				type: "item"
-			}]
-			title: "&2Fusion Reactor MK1"
-			x: -4.0d
-			y: -3.5d
-		}
-		{
-			dependencies: ["70EFDBB0FFC9B28D"]
+			dependencies: ["1FD2D0855A8A926B"]
 			description: ["&3Large Plasma Turbines&r are a powerful late game method of generating power. One Large Plasma Turbine produces &2a base of 16384 EU/t when using an IV Rotor Holder&r."]
+			icon: "gtceu:plasma_large_turbine"
 			id: "1405D08C6A87B3BB"
 			rewards: [{
 				id: "265F8AF395C89377"
 				item: "kubejs:nomi_dollar"
 				type: "item"
 			}]
-			tasks: [{
-				id: "5CA6A3EE3EF632F5"
-				item: "gtceu:plasma_large_turbine"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "5CA6A3EE3EF632F5"
+					item: "gtceu:plasma_large_turbine"
+					type: "item"
+				}
+				{
+					count: 28L
+					id: "6324614154FC58BF"
+					item: "gtceu:tungstensteel_turbine_casing"
+					type: "item"
+				}
+				{
+					count: 2L
+					id: "3D5916D81DAB1BCC"
+					item: "gtceu:tungstensteel_gearbox"
+					type: "item"
+				}
+			]
 			title: "&2Plasma Turbine"
 			x: -4.0d
 			y: -5.0d
 		}
 		{
-			dependencies: ["70EFDBB0FFC9B28D"]
+			dependencies: ["1FD2D0855A8A926B"]
 			description: [
 				"With a &3Fusion Reactor&r, you can make Europium!"
 				""
@@ -80,11 +75,6 @@
 				"You make it by fusing molten &9Neodymium&r and &9Hydrogen&r."
 			]
 			id: "25E1DE210726372E"
-			rewards: [{
-				id: "4755D59B4D91BAB4"
-				item: "kubejs:nomi_dollar"
-				type: "item"
-			}]
 			tasks: [{
 				id: "6A87828F83C85FC9"
 				item: "gtceu:europium_ingot"
@@ -100,7 +90,7 @@
 			id: "1183B96529D08326"
 			rewards: [{
 				id: "064FF89D54EB9137"
-				item: "kubejs:nomi_dollar"
+				item: "kubejs:nomi_quarter"
 				type: "item"
 			}]
 			tasks: [{
@@ -113,7 +103,11 @@
 			y: -3.4928571428571473d
 		}
 		{
-			dependencies: ["1183B96529D08326"]
+			dependencies: [
+				"1183B96529D08326"
+				"10DD3A6BE5F9624D"
+				"6588C68DE6973BCC"
+			]
 			description: [
 				"Upgrade time! "
 				"...or building a new one, which is probably better."
@@ -128,34 +122,51 @@
 				""
 				"The &3Mark 2 Fusion Reactor&r has an energy buffer of &e320M EU&r."
 			]
+			icon: "gtceu:zpm_fusion_reactor"
 			id: "069773756716E192"
 			rewards: [{
+				count: 10
 				id: "27AA4E8C62913D0C"
-				item: "kubejs:nomi_dollar"
+				item: "kubejs:nomi_quarter"
 				type: "item"
 			}]
-			tasks: [{
-				id: "1318C0E509554BEF"
-				item: "gtceu:zpm_fusion_reactor"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "1318C0E509554BEF"
+					item: "gtceu:zpm_fusion_reactor"
+					type: "item"
+				}
+				{
+					count: 16L
+					id: "4F996D6D51BF9050"
+					item: "gtceu:zpm_energy_input_hatch"
+					type: "item"
+				}
+				{
+					count: 48L
+					id: "01C009785BE10D67"
+					item: "gtceu:fusion_casing_mk2"
+					type: "item"
+				}
+				{
+					count: 4L
+					id: "3F8428A9521D1FD9"
+					item: "gtceu:fusion_coil"
+					type: "item"
+				}
+			]
 			title: "&2Fusion Reactor MK2"
 			x: 0.5d
 			y: -3.4928571428571473d
 		}
 		{
-			dependencies: ["069773756716E192"]
+			dependencies: ["5792330C6E5B87A3"]
 			description: [
 				"&2A lighter and unstable Naquadah isotope."
 				""
 				"&6Naquadria&o&r is used in the construction of &6UV components&r, the &3Fusion Reactor Mk2&r, and in fusing &6Neutronium&r. Each piece of Naquadria also makes &d4 times&r more power than &6Enriched Naquadah&r in &3Naquadah Reactors&r."
 			]
 			id: "10DD3A6BE5F9624D"
-			rewards: [{
-				id: "3DECE7737E023059"
-				item: "kubejs:nomi_dollar"
-				type: "item"
-			}]
 			tasks: [{
 				id: "4E4BF30AA04246D9"
 				item: "gtceu:naquadria_ingot"
@@ -168,14 +179,14 @@
 		{
 			dependencies: ["069773756716E192"]
 			description: [
-				"&2Do you remember Darmstadtium tools in CE? Well you can make their material now!"
+				"&2Do you remember Darmstadtium tools in CE? You can make their material now!"
 				""
 				"It is formed by fusing Arsenic and Ruthenium, and is the main material for UV machines."
 			]
 			id: "3FFC053E3E11D586"
 			rewards: [{
 				id: "51F748D4099BAC22"
-				item: "kubejs:nomi_dollar"
+				item: "kubejs:nomi_quarter"
 				type: "item"
 			}]
 			tasks: [{
@@ -232,7 +243,10 @@
 			y: -1.9928571428571473d
 		}
 		{
-			dependencies: ["79EFCD8E01384C0C"]
+			dependencies: [
+				"79EFCD8E01384C0C"
+				"5EE23A29090BD374"
+			]
 			description: [
 				"The final circuit!"
 				""
@@ -253,7 +267,11 @@
 			y: -1.9928571428571473d
 		}
 		{
-			dependencies: ["7D29C79DE1CCA2A2"]
+			dependencies: [
+				"7D29C79DE1CCA2A2"
+				"2D47BFA44BDB5E6A"
+			]
+			dependency_requirement: "one_completed"
 			description: [
 				"&6Neutronium&r is a hyper-dense material normally found in the hearts of neutron stars: the collapsed cores of stars between ten and thirty times the size of the sun."
 				""
@@ -264,11 +282,6 @@
 				"After getting &6Chaotic Fusion Injectors&r, you might consider using Tier Nine Micro Miners to supplement the fusion, as it is net-positive for Neutronium. These miners are expensive though, so it's up to you."
 			]
 			id: "0DF2AF70CB1FEFB3"
-			rewards: [{
-				id: "7BE5FDAE7CA95D53"
-				item: "kubejs:nomi_dollar"
-				type: "item"
-			}]
 			tasks: [{
 				id: "038C507EEFE6A5EE"
 				item: "gtceu:neutronium_ingot"
@@ -293,43 +306,37 @@
 				""
 				"The &3Mark 3 Fusion Reactor&r has an energy buffer of &e640M EU&r."
 			]
+			icon: "gtceu:uv_fusion_reactor"
 			id: "7D29C79DE1CCA2A2"
 			rewards: [{
+				count: 10
 				id: "342B04DA3362D0B9"
-				item: "kubejs:nomi_dollar"
+				item: "kubejs:nomi_quarter"
 				type: "item"
 			}]
 			subtitle: "FUSION!"
-			tasks: [{
-				id: "3816F5546D4E770F"
-				item: "gtceu:uv_fusion_reactor"
-				type: "item"
-			}]
+			tasks: [
+				{
+					id: "3816F5546D4E770F"
+					item: "gtceu:uv_fusion_reactor"
+					type: "item"
+				}
+				{
+					count: 48L
+					id: "5DA79E1DA2A1487B"
+					item: "gtceu:fusion_casing_mk3"
+					type: "item"
+				}
+				{
+					count: 16L
+					id: "59615AB26BAA31DA"
+					item: "gtceu:uv_energy_input_hatch"
+					type: "item"
+				}
+			]
 			title: "&2Fusion Reactor MK3"
 			x: 5.0d
 			y: -3.4928571428571473d
-		}
-		{
-			dependencies: ["7D29C79DE1CCA2A2"]
-			description: [
-				"&6Awakened Draconium&r is a powerful material used for crafting high-grade components, items, and machines from &bDraconic Evolution&r."
-				""
-				"Five &6Draconium Blocks&r can be processed in a Wyvern Tier fusion crafting setup to create an equal output of five &6Awakened Draconium Blocks&r. At &e24 Billion RF per craft&r, you better have a handle on your power infrastructure."
-			]
-			id: "4D0E5DE8475E126E"
-			rewards: [{
-				id: "5C2CDB46B35C0418"
-				item: "kubejs:nomi_dollar"
-				type: "item"
-			}]
-			tasks: [{
-				id: "013101DE01341EF9"
-				item: "gtceu:draconium_awakened_block"
-				type: "item"
-			}]
-			title: "Awakened Draconium"
-			x: 5.0d
-			y: -4.992857142857147d
 		}
 		{
 			dependencies: ["3FFC053E3E11D586"]
@@ -356,7 +363,10 @@
 			y: -3.4928571428571473d
 		}
 		{
-			dependencies: ["069773756716E192"]
+			dependencies: [
+				"069773756716E192"
+				"6728FB92FD3A2084"
+			]
 			description: [
 				"&6Americium Ingots&r are obtained by placing &dNuclearCraft&r Americium isotopes into an &3Extractor&r and solidifying the fluid. As with other GT materials, use the ingot or fluid to forge the other forms."
 				""
@@ -364,8 +374,8 @@
 			]
 			id: "4A8FB1EF600F0882"
 			rewards: [{
-				id: "3644007E720DE6EE"
-				item: "kubejs:nomi_dollar"
+				id: "28257AD592813E0D"
+				item: "kubejs:nomi_quarter"
 				type: "item"
 			}]
 			tasks: [{
@@ -416,18 +426,11 @@
 			]
 			icon: "gtceu:uranium_235_ingot"
 			id: "32E44FFD602C98DF"
-			rewards: [
-				{
-					id: "218573064D1473A9"
-					item: "kubejs:nomi_dollar"
-					type: "item"
-				}
-				{
-					id: "68479431103FCCB9"
-					item: "kubejs:nomi_dollar"
-					type: "item"
-				}
-			]
+			rewards: [{
+				id: "218573064D1473A9"
+				item: "kubejs:nomi_dollar"
+				type: "item"
+			}]
 			tasks: [
 				{
 					id: "07880B6CCD7BA77E"
@@ -791,22 +794,6 @@
 			y: -8.75d
 		}
 		{
-			dependencies: ["6728FB92FD3A2084"]
-			id: "44DB15CD523E56A0"
-			rewards: [{
-				id: "3F5954B22A73426B"
-				item: "kubejs:nomi_dollar"
-				type: "item"
-			}]
-			tasks: [{
-				id: "2CC704A973198831"
-				item: "gtceu:americium_ingot"
-				type: "item"
-			}]
-			x: -1.0d
-			y: -7.0d
-		}
-		{
 			dependencies: ["7D7B34CF5145F971"]
 			id: "171EE3A4129F19A5"
 			rewards: [{
@@ -846,6 +833,87 @@
 			title: "Further Adventures In Fission"
 			x: 3.5d
 			y: -9.5d
+		}
+		{
+			dependencies: [
+				"57627DCF9F46A8E2"
+				"7D39A4D0CC886796"
+				"6DAB13A7BDECE94E"
+			]
+			description: [
+				"The &3Fusion Reactor&r is a multiblock that uses enormous amounts of energy to fuse fluids into new elements. This one is less flexible than the previous GregTech multiblocks, as you can only put hatches where the preview shows. &6Sneak-right click&r the controller to enable the in-world preview."
+				""
+				"The &bJEI&r preview shows &eall valid hatch locations&r, but you don't actually need that many fluid hatches. You can replace any of the hatch positions in the structure with &2Fusion Machine Casings&r as long as you have at least &atwo Fluid Input Hatches&r and &aone Fluid Output Hatch&r. It's possible to use input/output hatches in every valid location, if you prefer."
+				""
+				"Because of this, the quest only asks for &248 Fusion Machine Casings&r. If you want to use the minimum number of fluid hatches, you'll need to craft an additional &229 Fusion Machine Casings&r. In addition to the &a48 Fusion Machine Casings&r, you will also need &631 Fusion Glass&r or &631 Fusion Machne Casings&r. &bFusion Glass is cheaper, and looks cooler&r, but its your choice."
+				""
+				"Each &aEnergy Hatch&r increases the reactor's power buffer. &2You cannot use 4x or 16x Energy Hatches in Fusion Reactors. &aAll 16 Energy Hatches&r are required to be able to process all Mark 1 recipes and give a power buffer of &e160M EU&r. &2However, not all energy hatches are needed to be connected to power. For example, a recipe that requires LuV power draw would only need one or more hatches connected to power, but a recipe that needs ZPM power draw would need two hatches connected to power.&r &cThey still need to be present on the structure!&r"
+				""
+				"In addition to the recipe power drain, Fusion Reactors have a &eheat&r mechanic related to the recipe's &e\"Eu to Start\"&r. This amount of power is drained from the reactor's buffer before starting the recipe to heat up the reactor to the necessary temperature, and is independent of the recipe's EU/t cost. As such, this determines the minimum tier of reactor you need for a recipe."
+				""
+				"If the reactor stops processing, it will &erapidly lose heat&r, even if you pause it with a soft hammer. On the other hand, if the reactor is already at the required temperature for a recipe, &eno additional power&r is required to heat up the reactor! This is true even if you switch between different recipes. This mechanic incentivizes continuous use of the reactor."
+				""
+				"If you switch to a recipe that requires more heat, &eonly the difference&r in heat values is consumed as EU to reach the target heat (up to a maximum heat equal to the reactor's current buffer)."
+				""
+				"Fusion Reactors &2overclock, but only once per fusion tier, instead of based on energy input.&r They gate the next tier of materials, so you will eventually want to make more than one."
+			]
+			icon: "gtceu:luv_fusion_reactor"
+			id: "1FD2D0855A8A926B"
+			size: 1.0d
+			subtitle: "Time to get fusing!"
+			tasks: [
+				{
+					id: "5E005EC2DD551FB2"
+					item: "gtceu:luv_fusion_reactor"
+					type: "item"
+				}
+				{
+					count: 2L
+					id: "19392B2E76B8C49C"
+					item: {
+						Count: 1b
+						id: "itemfilters:tag"
+						tag: {
+							value: "nomi:input_hatch"
+						}
+					}
+					title: "Any #nomi:input_hatch"
+					type: "item"
+				}
+				{
+					id: "67D16E6904489436"
+					item: {
+						Count: 1b
+						id: "itemfilters:tag"
+						tag: {
+							value: "nomi:output_hatch"
+						}
+					}
+					title: "Any #nomi:output_hatch"
+					type: "item"
+				}
+				{
+					count: 16L
+					id: "2563EFC2CBD0B6FC"
+					item: "gtceu:luv_energy_input_hatch"
+					type: "item"
+				}
+				{
+					count: 4L
+					id: "25059EA27042EA4D"
+					item: "gtceu:superconducting_coil"
+					type: "item"
+				}
+				{
+					count: 48L
+					id: "0ABFCF5809C3F463"
+					item: "gtceu:fusion_casing"
+					type: "item"
+				}
+			]
+			title: "&2Fusion Reactor MK1"
+			x: -4.0d
+			y: -3.5d
 		}
 	]
 	title: "Fission and Fusion"

--- a/config/ftbquests/quests/chapters/genesis.snbt
+++ b/config/ftbquests/quests/chapters/genesis.snbt
@@ -11,13 +11,11 @@
 		{
 			dependencies: ["2A511DB40C66CF35"]
 			description: [
-				"This pack is intended to be played in a &bLost cities/Overworld dimension&r"
+				"This pack is intended to be played in a &bLost cities/Overworld dimension&r."
 				""
-				"If you're playing with friends, don't forget to invite them to the"
-				"&eFTB Teams party&r. "
+				"If you're playing with friends, don't forget to invite them to the &eFTB Teams party&r. "
 				""
-				"If you wish to build your base in a skyblock world, place the &6Void World Cake&r down on the ground, and eat a slice to be sent"
-				"to the void. Please note that you'll still need to return to the Lost Cities/Overworld dimension to mine, but you can freely build in complete safety in the &eVoid&r"
+				"If you wish to build your base in a skyblock world, place the &6Void World Cake&r down on the ground, and eat a slice to be sent to the void. Please note that you'll still need to return to the Lost Cities/Overworld dimension to mine, but you can freely build in complete safety in the &eVoid World&r."
 				""
 				"Features new to &2CEu&r and quests with new content will be higlighted in &2dark green&r."
 				""
@@ -324,13 +322,11 @@
 		{
 			dependencies: ["2E8BFA2E719B1C47"]
 			description: [
-				"One of the eccentricities of the pack you'll need to get used to is the way the tools are displayed. Most tools can be made out of nearly any metal, and &bJEI&f will display a huge number of options... every combination of every tool with every material. However, the pattern to make the tool is always identical, so &ejust arrange the plates and ingots in the same manner as the examples, ignoring whatever material it says&f. Rods where rods go, plates where plates, etc. The only restriction is that tools &emust be made from all of the same material&f... you cannot mix and match different metals in a single item."
+				"&dWith EMI, instead of showing you a separate recipe for every tool-resource combination, tools are instead grouped. You can use any any tool from that group - for example, the &6#forge:tools/hammers &dgroup means that any &aHammer &dcan be used there."
 				""
-				"Recipes will default to showing a &6Iron tool &rof the appropriate type if a tool is required, but the correct type of tool made out of any metal will work. Just ignore the tool's material in the recipes: it can be whatever you'd like."
+				"First, make a &aHammer&f (not a &aMining Hammer&f, mind you... six ingots, not plates). Hammers can be used to turn &etwo ingots into one plate&f. &6Plates&f can make a &aFile&f, Files can make &6Rods&f, etc. Use EMI to work your way down the list of tools."
 				""
-				"For now, make a &aHammer&f (not a &aMining Hammer&f, mind you... six ingots, not plates). Hammers can be used to turn &etwo ingots into one plate&f. &6Plates&f can make a &aFile&f, Files can make &6Rods&f, etc. Use JEI to work your way down the list of tools."
-				""
-				"&6Wrought Iron&f is probably your best bet for a tool material right now, but better materials will become available as you progress. This quest accepts any tool material."
+				"&6Wrought Iron&f is probably your best bet for a tool material right now, but better materials will become available as you progress."
 			]
 			icon: {
 				Count: 1b
@@ -1373,7 +1369,7 @@
 				"12B95158E4C792DB"
 			]
 			description: [
-				"This is where your &3Crafting Station&f setups will really shine! With the patterns encoded into a Crafting Stations (well, really over &omany&r Crafting Stations), you'll be able to &ebatch craft circuits quickly&f."
+				"&dThis is where &bEMI&d really shines! Using it alongside &3Crafting Stations&d, you should be able to easily calculate the amount of raw resources and intermediate components you'll need to &ebatch craft &delectronic circuits quickly."
 				""
 				"You'll be making a LOT&r of circuits, so take advantage of the improved crafting efficiency."
 			]
@@ -1570,13 +1566,26 @@
 		}
 		{
 			dependencies: ["2FA9404468E4BBD9"]
+			description: [
+				"&6Batteries&r are &bGregTech &rpower storage for &aEU&r energy."
+				""
+				"Although there are several types of rechargeable batteries you can make, &2Lithium Batteries&r are the best ones, and the only ones you should really consider making."
+				""
+				"&6Lithium&r is possible to find inside of &6Tungsten&r veins, however, they are fairly rare. Consider \"buying\" some Lithium with &dNomicoins&r."
+			]
 			id: "077AA27F26B7831F"
+			rewards: [{
+				id: "0630EB540FFAC21C"
+				item: "kubejs:nomi_nickel"
+				type: "item"
+			}]
 			tasks: [{
 				count: 4L
 				id: "7923DEDAB3298371"
 				item: { Count: 4b, id: "gtceu:lv_battery_hull" }
 				type: "item"
 			}]
+			title: "LV Power Storage"
 			x: -2.5d
 			y: 10.5d
 		}

--- a/config/ftbquests/quests/chapters/late_game.snbt
+++ b/config/ftbquests/quests/chapters/late_game.snbt
@@ -1804,7 +1804,10 @@
 			y: 16.75d
 		}
 		{
-			dependencies: ["5792330C6E5B87A3"]
+			dependencies: [
+				"5792330C6E5B87A3"
+				"0562D9F4C441EAF9"
+			]
 			description: ["A complex plating material used exclusively for the Tier Nine Micro Miner."]
 			id: "57D9FA04817CB92F"
 			rewards: [{
@@ -1823,7 +1826,7 @@
 			y: 18.25d
 		}
 		{
-			dependencies: ["5792330C6E5B87A3"]
+			dependencies: ["7FAB6FD0A054443E"]
 			description: [
 				"You don't need it just yet, but you can make it now."
 				""
@@ -1848,6 +1851,7 @@
 			dependencies: [
 				"2358A5CF22FF5495"
 				"7E3A179376673590"
+				"0B6196692F9E176D"
 			]
 			description: [
 				"The source of &6Dragon Hearts&r and the valuable &6Lair of The Chaos Guardian Data&r."
@@ -2003,7 +2007,7 @@
 			y: 8.25d
 		}
 		{
-			dependencies: ["0B6196692F9E176D"]
+			dependencies: ["1CC092A2F2CD4589"]
 			description: [
 				"&6Draconic Cores&r are the first crafting step into &bDraconic Evolution&r."
 				""
@@ -2048,11 +2052,7 @@
 			y: 10.25d
 		}
 		{
-			dependencies: [
-				"57D9FA04817CB92F"
-				"5FE96C30454A0374"
-				"4DF92773C82F4AAC"
-			]
+			dependencies: ["5FE96C30454A0374"]
 			description: ["&6Dragon Hearts&r are needed for both &6Awakened Draconium&r and &6The Ultimate Material&r."]
 			id: "7FAB6FD0A054443E"
 			rewards: [{
@@ -2302,6 +2302,7 @@
 				"57D9FA04817CB92F"
 				"619D94FE1D9834FA"
 				"6ABD83B58FADD4DF"
+				"483652BAEF59E125"
 			]
 			description: [
 				"Combines &bStellar Creation Data&r into the &dUniverse Creation Data&r, which is a crucial component for the Tier Ten Micro Miner mission."
@@ -2327,8 +2328,8 @@
 		}
 		{
 			dependencies: [
-				"6BF4A76C5B84EEE9"
 				"03F04B4005F2CBE1"
+				"738A141D31AD7CE3"
 			]
 			description: [
 				"The &6Reactor Stabilizer&r is a component needed for the Tier Nine and Tier Ten Micro Miners, as well as a component in a few Endgame recipes."
@@ -2411,7 +2412,6 @@
 			dependencies: [
 				"22E50A6923EBF5CB"
 				"235C1E5B2C58B5AF"
-				"483652BAEF59E125"
 			]
 			description: [
 				"The highest tier of fusion crafting injectors. You will need at least ten of these to reach the &dCreative Tank&r."
@@ -2716,7 +2716,7 @@
 		}
 		{
 			dependencies: ["3E51686E2DBD380F"]
-			description: [" &6TNT&r is an explosive made from &9Toluene&r, a distillation byproduct of &9Wood Tar&r or various &eSteam-Cracked Fuels&r. Besides its typical uses in Minecraft, it is a crafting ingredient you can use in the &3Implosion Compressor&r."]
+			description: ["&6TNT&r is an explosive made from &9Toluene&r, a distillation byproduct of &9Wood Tar&r or various &eSteam-Cracked Fuels&r. Besides its typical uses in Minecraft, it is a crafting ingredient you can use in the &3Implosion Compressor&r."]
 			id: "25B0271106684DF7"
 			rewards: [{
 				id: "3025735A47D591DE"

--- a/config/ftbquests/quests/chapters/late_game.snbt
+++ b/config/ftbquests/quests/chapters/late_game.snbt
@@ -76,7 +76,7 @@
 					type: "item"
 				}
 			]
-			title: "Medium Microverse Projector"
+			title: "Advanced Microverse Projector"
 			x: 3.0d
 			y: -2.0d
 		}
@@ -1903,8 +1903,6 @@
 				"15FAEE3F625265F4"
 			]
 			description: [
-				"Time to get fusing!"
-				""
 				"The &3Fusion Reactor&r is a multiblock that uses enormous amounts of energy to fuse fluids into new elements. This one is less flexible than the previous GregTech multiblocks, as you can only put hatches where the preview shows. &6Sneak-right click&r the controller to enable the in-world preview."
 				""
 				"The &bJEI&r preview shows &eall valid hatch locations&r, but you don't actually need that many fluid hatches. You can replace any of the hatch positions in the structure with &2Fusion Machine Casings&r as long as you have at least &atwo Fluid Input Hatches&r and &aone Fluid Output Hatch&r. It's possible to use input/output hatches in every valid location, if you prefer."
@@ -1930,6 +1928,7 @@
 				type: "item"
 			}]
 			size: 2.0d
+			subtitle: "Time to get fusing!"
 			tasks: [
 				{
 					id: "58C69AD21BA53BEB"
@@ -2376,7 +2375,11 @@
 			y: 21.0d
 		}
 		{
-			dependencies: ["2D47BFA44BDB5E6A"]
+			dependencies: [
+				"2D47BFA44BDB5E6A"
+				"7D29C79DE1CCA2A2"
+			]
+			dependency_requirement: "one_completed"
 			description: [
 				"&6Neutronium&r is a hyper-dense material normally found in the hearts of neutron stars: the collapsed cores of stars between ten and thirty times the size of the sun."
 				""
@@ -3039,7 +3042,10 @@
 			y: 1.0d
 		}
 		{
-			dependencies: ["5EE23A29090BD374"]
+			dependencies: [
+				"5EE23A29090BD374"
+				"79EFCD8E01384C0C"
+			]
 			description: [
 				"The only novel ingredient is &6Tritanium Frames&r."
 				""


### PR DESCRIPTION
Most changes have been made to the Fission and Fusion chapter.
-Lots of double-dipping rewards removed
-Many quest rewards changed to be consistent with CEu
-Some redundant quests removed (like Awakened Draconium, which I didn't think should be in this chapter, at least not yet)
-Changed a few dependencies on duplicate quests to make the quest-book flow better (for example, previously, Trinium would be greyed out in the Fusion chapter even when 'Available, but Incomplete' in Endgame. Their states should now sync properly). This is potentially more broadly applicable. I also noticed Linked Quests - might be useful, but I haven't had a play around with it yet.
-Linked Fission and Fusion lines through Americium. Probably could have some stuff shifted around to make it look a bit nicer.
-Fixed some incorrect dependencies (i.e. Naquadria requiring Fusion MK2, not the other way around)
-Renamed 'Medium Microverse Projector' quest to 'Advanced Microverse Projector' for consistency with later quests.
-Updated a few quest descriptions and fixed some minor grammatical errors. In particular, I adjusted a few references to old JEI quirks and Crafting Stations (RIP) in Genesis to now reference the new stuff in EMI, most notably tools being grouped by tags in recipes & recipe trees. I'm not sure my explanations of these new features are super fantastic, so it'd be good for someone more eloquent to take a look and make changes if necessary.