### PR TITLE
Clean up ore smelting recipes

### DIFF
--- a/kubejs/server_scripts/ore_smelting.js
+++ b/kubejs/server_scripts/ore_smelting.js
@@ -1,0 +1,42 @@
+ServerEvents.recipes(event => {
+	//Remvoe overlapping ore blocks to ingot/dust recipes
+	event.remove( { id: "minecraft:nuclearcraft_lithium_ore"})
+	event.remove( { id: "minecraft:nuclearcraft_cobalt_ore" })
+	event.remove( { id: "minecraft:copper_ingot_from_smelting_copper_ore" })
+	event.remove( { id: "minecraft:gold_ingot_from_smelting_deepslate_gold_ore" })
+	event.remove( { id: "minecraft:iron_ingot_from_smelting_deepslate_iron_ore" })
+	event.remove( { id: "thermal:smelting/lead_ingot_from_deepslate_ore_smelting" })
+	event.remove( { id: "minecraft:nuclearcraft_lead_ore" })
+	event.remove( { id: "thermal:smelting/nickel_ingot_from_deepslate_ore_smelting" })
+	event.remove( { id: "minecraft:nuclearcraft_platinum_ore" })
+	event.remove( { id: "minecraft:nuclearcraft_silver_ore" })
+	event.remove( { id: "thermal:smelting/silver_ingot_from_deepslate_ore_smelting" })
+	event.remove( { id: "thermal:smelting/sulfur_from_smelting" })
+	event.remove( { id: "minecraft:nuclearcraft_thorium_ore" })
+	event.remove( { id: "minecraft:nuclearcraft_tin_ore" })
+	event.remove( { id: "thermal:smelting/tin_ingot_from_deepslate_ore_smelting" })
+	event.remove( { id: "thermal:smelting/cinnabar_from_smelting" })
+	event.remove( { id: "minecraft:coal_from_smelting_coal_ore" })
+	event.remove( { id: "minecraft:diamond_from_smelting_deepslate_diamond_ore" })
+	event.remove( { id: "minecraft:emerald_from_smelting_deepslate_emerald_ore" })
+	event.remove( { id: "minecraft:lapis_lazuli_from_smelting_deepslate_lapis_ore" })
+	event.remove( { id: "thermal:smelting/apatite_from_smelting" })
+
+	//Remove overlapping raw ore to ingot recipes
+	event.remove( { id: "minecraft:nuclearcraft_silver_raw" })
+	event.remove( { id: "" })
+
+	//redstone and lapis ores now drop multiple raw ore per ore block. They are tedious to smelt so we speed them up
+	let quickSmelt = function(oreName, output) {
+		event.remove( {id:"gtceu:smelting/smelt_raw_"+ oreName +"_ore_to_ingot"})
+		event.remove( {id:"gtceu:blasting/smelt_raw_"+ oreName +"_ore_to_ingot"})
+		event.smelting(output, "gtceu:raw_"+ oreName).id("gtceu:smelting/smelt_raw_"+ oreName +"_ore_to_ingot").cookingTime(50)
+		event.blasting(output, "gtceu:raw_"+ oreName).id("gtceu:blasting/smelt_raw_"+ oreName +"_ore_to_ingot").cookingTime(50)
+	}
+	quickSmelt("redstone", "minecraft:redstone")
+	quickSmelt("electrotine", "gtceu:electrotine_dust")
+
+	quickSmelt("lapis", "minecraft:lapis_lazuli")
+	quickSmelt("lazurite", "gtceu:lazurite_gem")
+	quickSmelt("sodalite", "gtceu:sodalite_gem")
+})

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -674,4 +674,15 @@ ServerEvents.recipes(event => {
             B: '#minecraft:swords'
         }
     ).damageIngredient('#minecraft:swords')
+
+		//Wooden rods from armor plus are easy to accidentally craft instead of wood gears. Turn it into a shaped recipe
+		event.remove( {id: "armorplus:crafting/shapeless/wooden_rod" })
+		event.shaped(
+			'2x armorplus:wooden_rod', [
+				'SS',
+				'SS'
+			], {
+				S: 'minecraft:stick'
+			}
+		).id('kubejs:not_a_wood_gear')
 })

--- a/kubejs/server_scripts/temp.js
+++ b/kubejs/server_scripts/temp.js
@@ -23,26 +23,6 @@ ServerEvents.recipes(event => {
             }
         )
 
-	event.remove( {id:"gtceu:smelting/smelt_raw_coal_ore_to_ingot"})
-	event.smelting( "2x minecraft:coal", "gtceu:raw_coal" ).id("gtceu:smelting/smelt_raw_coal_ore_to_ingot")
-	event.remove( {id:"gtceu:blasting/smelt_raw_coal_ore_to_ingot"})
-	event.blasting( "2x minecraft:coal", "gtceu:raw_coal" ).id("gtceu:blasting/smelt_raw_coal_ore_to_ingot")
-
-	event.remove( {id:"gtceu:smelting/smelt_raw_redstone_ore_to_ingot"})
-	event.smelting( "6x minecraft:redstone", "gtceu:raw_redstone" ).id("gtceu:smelting/smelt_raw_redstone_ore_to_ingot")
-	event.remove( {id:"gtceu:blasting/smelt_raw_redstone_ore_to_ingot"})
-	event.blasting( "6x minecraft:redstone", "gtceu:raw_redstone" ).id("gtceu:blasting/smelt_raw_redstone_ore_to_ingot")
-
-	event.remove( {id:"gtceu:smelting/smelt_raw_cassiterite_ore_to_ingot"})
-	event.smelting( "2x gtceu:tin_ingot", "gtceu:raw_cassiterite" ).id("gtceu:smelting/smelt_raw_cassiterite_ore_to_ingot")
-	event.remove( {id:"gtceu:blasting/smelt_raw_cassiterite_ore_to_ingot"})
-	event.blasting( "2x gtceu:tin_ingot", "gtceu:raw_cassiterite" ).id("gtceu:blasting/smelt_raw_cassiterite_ore_to_ingot")
-
-	event.remove( {id:"gtceu:smelting/smelt_raw_cassiterite_sand_ore_to_ingot"})
-	event.smelting( "2x gtceu:tin_ingot", "gtceu:raw_cassiterite_sand" ).id("gtceu:smelting/smelt_raw_cassiterite_sand_ore_to_ingot")
-	event.remove( {id:"gtceu:blasting/smelt_raw_cassiterite_sand_ore_to_ingot"})
-	event.blasting( "2x gtceu:tin_ingot", "gtceu:raw_cassiterite_sand" ).id("gtceu:blasting/smelt_raw_cassiterite_sand_ore_to_ingot")
-
 
     // temp iron chest > sophisticated barrel recipe
 


### PR DESCRIPTION
Remove 1 raw ore -> multiple result ore smelting recipes. Gtceu drops multiple raw ores per block instead.
Remove duplicate ore smelting recipes coming from minecraft, thermal, and nuclearcraft.
Speed up tedious raw ore smelting recipes: redstone, electrotine, lapis, lazurite, sodalite.
Make the armorplus wooden_rod recipe shaped instead of shapeless so it no longer conflicts with the wooden gear recipe.