### PR TITLE
Issue fixes

### DIFF
--- a/kubejs/assets/minecraft/lang/en_us.json
+++ b/kubejs/assets/minecraft/lang/en_us.json
@@ -1,0 +1,4 @@
+{
+	"advancements.story.enter_the_nether.description": "Bake and eat a Nether Cake",
+	"advancements.story.enter_the_end.description": "Find a way into The End"
+}

--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -51,12 +51,4 @@ ItemEvents.tooltip(tooltip => {
     tooltip.addAdvanced(/simplybackpacks:/, (item, advanced, text) => {
         text.add(1, [Text.of('Deprecated, switch out for a sophisticated backpack.').red()])
     })
-
-    tooltip.addAdvanced(/sophisticatedbackpacks:backpack/, (item, advanced, text) => {
-        text.add(1, [Text.of('Items and upgrades in backpack will be lost if upgraded!').red()])
-    })
-
-    tooltip.addAdvanced(/sophisticatedbackpacks:[A-Za-z]+_backpack/, (item, advanced, text) => {
-        text.add(1, [Text.of('Items in backpack will be lost if upgraded!').red()])
-    })
 })

--- a/kubejs/server_scripts/mods/Sophisticated_Storage.js
+++ b/kubejs/server_scripts/mods/Sophisticated_Storage.js
@@ -55,8 +55,14 @@ ServerEvents.recipes(event => {
             L: material[1],
             T: material[2],
             C: material[3]
-        })
-    })
+        }).modifyResult((grid, result) => { //Copy the contentsUuid tag to the new item to transfer the inventory over
+					let item = grid.find(material[3])
+					if (item.nbt && item.nbt.contentsUuid) {
+						return result.withNBT({contentsUuid: item.nbt.contentsUuid})
+					}
+					return result;
+				})
+		})
 
     // Stack upgrades
 

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -631,4 +631,8 @@ ServerEvents.recipes(event => {
 				S: 'minecraft:stick'
 			}
 		).id('kubejs:not_a_wood_gear')
+
+		//Bounty board recipes only accept oak. The dev has stated this is intended. https://github.com/ejektaflex/Bountiful/issues/271
+		event.replaceInput( { id:"bountiful:crafting/bountyboard"}, "minecraft:oak_log", "#minecraft:logs")
+		event.replaceInput( { id:"bountiful:crafting/bountyboard"}, "minecraft:oak_planks", "#minecraft:planks")
 })


### PR DESCRIPTION
Fix issue #183 by making the bounty board accept all wood types.
Fix issue #185 by changing the nether and end advancement descriptions.
Fix issue #186 by copying the contentsUuid nbt to the new item only if the nbt exists on the old item.