### PR TITLE
Rework bounty board to (hopefully) make it more balanced

### DIFF
--- a/config/bountiful/bounty_pools/nomi_objs.json
+++ b/config/bountiful/bounty_pools/nomi_objs.json
@@ -30,8 +30,8 @@
 				"min": 2,
 				"max": 5
 			},
-			"unitWorth": 15,
-			"rarity": "UNCOMMON"
+			"unitWorth": 20,
+			"rarity": "RARE"
 		},
 		"all_obj_ender_widget": {
 			"type": "item",
@@ -40,7 +40,7 @@
 				"min": 2,
 				"max": 5
 			},
-			"unitWorth": 20,
+			"unitWorth": 30,
 			"rarity": "EPIC"
 		},
 		"all_obj_lv_con": {
@@ -60,7 +60,7 @@
 				"min": 2,
 				"max": 4
 			},
-			"unitWorth": 10,
+			"unitWorth": 12,
 			"rarity": "UNCOMMON"
 		},
 		"all_obj_lv_robot_arm": {
@@ -68,9 +68,9 @@
 			"content": "gtceu:lv_robot_arm",
 			"amount": {
 				"min": 2,
-				"max": 4
+				"max": 5
 			},
-			"unitWorth": 15,
+			"unitWorth": 25,
 			"rarity": "EPIC"
 		},
 		"all_obj_lv_circuit": {
@@ -80,8 +80,30 @@
 				"min": 5,
 				"max": 10
 			},
-			"unitWorth": 12,
-			"rarity": "RARE"
+			"unitWorth": 15,
+			"rarity": "EPIC"
+		},
+
+		"all_obj_alloy_widget_legendary": {
+			"type": "item",
+			"content": "kubejs:alloy_widget",
+			"amount": {
+				"min": 6,
+				"max": 10
+			},
+			"unitWorth": 20,
+			"rarity": "LEGENDARY"
+		},
+
+		"all_obj_ender_widget_legendary": {
+			"type": "item",
+			"content": "kubejs:ender_widget",
+			"amount": {
+				"min": 6,
+				"max": 10
+			},
+			"unitWorth": 30,
+			"rarity": "LEGENDARY"
 		}
 	
 	}

--- a/config/bountiful/bounty_pools/nomi_objs.json
+++ b/config/bountiful/bounty_pools/nomi_objs.json
@@ -70,17 +70,17 @@
 				"min": 2,
 				"max": 5
 			},
-			"unitWorth": 25,
+			"unitWorth": 24,
 			"rarity": "EPIC"
 		},
 		"all_obj_lv_circuit": {
 			"type": "item",
 			"content": "gtceu:basic_electronic_circuit",
 			"amount": {
-				"min": 5,
-				"max": 10
+				"min": 2,
+				"max": 8
 			},
-			"unitWorth": 15,
+			"unitWorth": 8,
 			"rarity": "EPIC"
 		},
 

--- a/config/bountiful/bounty_pools/nomi_rews.json
+++ b/config/bountiful/bounty_pools/nomi_rews.json
@@ -5,7 +5,7 @@
 			"type": "item",
 			"content": "kubejs:nomi_penny",
 			"amount": {
-				"min": 10,
+				"min": 20,
 				"max": 50
 			},
 			"unitWorth": 1,
@@ -16,19 +16,19 @@
 			"type": "item",
 			"content": "kubejs:nomi_nickel",
 			"amount": {
-				"min": 10,
-				"max": 20
+				"min": 8,
+				"max": 15
 			},
 			"unitWorth": 5,
-			"rarity": "COMMON"
+			"rarity": "UNCOMMON"
 		},
 
 		"all_rew_nomi_quarter": {
 			"type": "item",
 			"content": "kubejs:nomi_quarter",
 			"amount": {
-				"min": 5,
-				"max": 10
+				"min": 2,
+				"max": 4
 			},
 			"unitWorth": 25,
 			"rarity": "RARE"
@@ -39,10 +39,20 @@
 			"content": "kubejs:nomi_dollar",
 			"amount": {
 				"min": 1,
+				"max": 1
+			},
+			"unitWorth": 125,
+			"rarity": "EPIC"
+		},
+		"all_rew_nomi_dollar_legendary": {
+			"type": "item",
+			"content": "kubejs:nomi_dollar",
+			"amount": {
+				"min": 2,
 				"max": 3
 			},
-			"unitWorth": 100,
-			"rarity": "EPIC"
+			"unitWorth": 125,
+			"rarity": "LEGENDARY"
 		}
 	}
 }

--- a/config/bountiful/bounty_pools/nomi_rews.json
+++ b/config/bountiful/bounty_pools/nomi_rews.json
@@ -16,8 +16,8 @@
 			"type": "item",
 			"content": "kubejs:nomi_nickel",
 			"amount": {
-				"min": 8,
-				"max": 15
+				"min": 6,
+				"max": 12
 			},
 			"unitWorth": 5,
 			"rarity": "UNCOMMON"
@@ -28,7 +28,7 @@
 			"content": "kubejs:nomi_quarter",
 			"amount": {
 				"min": 2,
-				"max": 4
+				"max": 3
 			},
 			"unitWorth": 25,
 			"rarity": "RARE"
@@ -41,7 +41,7 @@
 				"min": 1,
 				"max": 1
 			},
-			"unitWorth": 125,
+			"unitWorth": 100,
 			"rarity": "EPIC"
 		},
 		"all_rew_nomi_dollar_legendary": {
@@ -51,7 +51,7 @@
 				"min": 2,
 				"max": 3
 			},
-			"unitWorth": 125,
+			"unitWorth": 100,
 			"rarity": "LEGENDARY"
 		}
 	}

--- a/config/inventorysorter-client.toml
+++ b/config/inventorysorter-client.toml
@@ -1,8 +1,0 @@
-
-#Inventory sorter modules
-[modules]
-	#Sorting module
-	sortingmodule = true
-	#Wheel move module
-	wheelmovemodule = true
-

--- a/kubejs/server_scripts/mods/bountiful.js
+++ b/kubejs/server_scripts/mods/bountiful.js
@@ -20,7 +20,7 @@ event.shaped(
         S: '#minecraft:wooden_slabs',
         A: '#forge:tools/saws',
     }
-)
+).noMirror()
 event.shaped(
     'kubejs:wooden_widget', [
         'LGR'
@@ -29,7 +29,7 @@ event.shaped(
         G: 'enderio:wood_gear',
         R: 'kubejs:wooden_widget_right'
     }
-)
+).noMirror()
 
 event.shaped(
     'kubejs:stone_widget_up', [


### PR DESCRIPTION
It turns out that bounties actually generate their reward first and then generate the items needed to try to get close to that. This caused it to fail pretty hard previously since it could generate a 3 nomicoin bounty (worth 300 units) when there are no requestable items that are worth 300 units.
Units are how bountiful balances out bounties. If a bounty has a 300 unit reward. It'll try to find items worth 300 units. 1 unit = 1 nomicoin.

Reworks bounty board tables:
-minimum nomicoins per bounty increased to 20 nomicoints to prevent bounty from giving a negligible reward
-nominickels are now uncommon bounties and only give 6-12 per bounty
-nomidimes are now only given in amounts from 2-3 per bounty
-nomidollar(rare) bounty reduced to only 1 nomidollar
-nomidollar legandary bounty added that gives 2-3 nomidollars (much more rare than the other ones)

-Alloy widgets increased to 20 units each (same as ceu) and is now rare rarity bounty
-ender widgets increased to 30 units each (same as ceu)
-conveyors increased to 10 units each
-pumps increased to 12 units each
-circuits decreased to 8 units each and is now an epic rarity bounty
-robot arms increased to 24 units each

The amount of coins given per bounty got reduced to make lower cost bounties more common.

Legendary tier alloy and ender widget bounties were added to help prevent high reward bounties from underrequesting items. These will only show up in high reward bounties and won't appear in lower reward bounties. Previously you would see bounties that give 3 nomidollars for 25 stone widgets and these higher count widget bounties help prevent that from happening.

It is still possible to get 3 nomidollar bounties from legendary bounties but they are extremely rare now.



This PR also fixes wood widget part recipes being mirrorable (causing them to conflict with eachother).