### PR TITLE
Glasses

### DIFF
--- a/kubejs/server_scripts/glass_breaking.js
+++ b/kubejs/server_scripts/glass_breaking.js
@@ -1,0 +1,7 @@
+ServerEvents.tags('block', event => {
+	// Makes you mine glass faster using a pickaxe
+	event.add('minecraft:mineable/pickaxe', ['#forge:glass', '#forge:glass_panes']);
+	event.add('minecraft:mineable/pickaxe', /xtonesreworked:glaxx_block_/);
+	event.add('minecraft:mineable/pickaxe', /enderio:clear_glass/);
+	event.add('minecraft:mineable/pickaxe', /enderio:fused_quartz/);
+})

--- a/kubejs/server_scripts/gregtech/Actually_Additions.js
+++ b/kubejs/server_scripts/gregtech/Actually_Additions.js
@@ -26,6 +26,26 @@ ServerEvents.recipes(event => {
     event.remove({ id: /gtceu:shaped\/gear_\w+_empowered/g })
     event.remove({ output: ['gtceu:enori_gear', 'gtceu:void_gear', 'gtceu:palis_gear', 'gtceu:diamatine_gear', 'gtceu:restonia_gear', 'gtceu:emeradic_gear'] })
 
+		// Black Quartz
+		event.recipes.gtceu.electrolyzer("kubejs:black_quartz_dust")
+			.itemInputs("4x gtceu:quartzite_dust")
+			.itemOutputs("gtceu:black_quartz_dust")
+			.duration(400)
+			.EUt(90)
+		event.recipes.gtceu.autoclave('kubejs:black_quartz_gem__water')
+		.itemInputs('gtceu:black_quartz_dust')
+		.inputFluids(Fluid.of('minecraft:water', 250))
+		.itemOutputs('gtceu:black_quartz_gem')
+		.duration(1200)
+		.EUt(24)
+		event.recipes.gtceu.autoclave('kubejs:black_quartz_gem__distilled')
+		.itemInputs('gtceu:black_quartz_dust')
+		.inputFluids(Fluid.of('gtceu:distilled_water', 50))
+		.itemOutputs('gtceu:black_quartz_gem')
+		.duration(600)
+		.EUt(24)
+
+
     // Reconstruction
     reconstructedItems.forEach(itemPair => {
         event.recipes.gtceu.atomic_reconstruction(itemPair[2])

--- a/kubejs/server_scripts/mods/EnderIO.js
+++ b/kubejs/server_scripts/mods/EnderIO.js
@@ -281,7 +281,7 @@ ServerEvents.recipes(event => {
 
     // dark fused quartz (FIXME: replace bedrock with actual AA item, was too lazy to fire up normal nomi to see)
     event.recipes.gtceu.alloy_smelter("dark_fused_quartz")
-        .itemInputs('#enderio:fused_quartz', 'minecraft:bedrock')
+        .itemInputs('#enderio:fused_quartz', 'gtceu:black_quartz_gem')
         .itemOutputs('enderio:fused_quartz_d')
         .duration(200)
         .EUt(32)
@@ -295,7 +295,7 @@ ServerEvents.recipes(event => {
 
     // dark clear glass
     event.recipes.gtceu.alloy_smelter("dark_clear_glass")
-        .itemInputs('#enderio:clear_glass', 'minecraft:bedrock')
+        .itemInputs('#enderio:clear_glass', 'gtceu:black_quartz_gem')
         .itemOutputs('enderio:clear_glass_d')
         .duration(200)
         .EUt(32)

--- a/kubejs/server_scripts/unification/tags.js
+++ b/kubejs/server_scripts/unification/tags.js
@@ -26,8 +26,6 @@ ServerEvents.tags('item', event => {
 })
 
 ServerEvents.tags('block', event => {
-    event.add('minecraft:mineable/pickaxe', ['forge:glass', 'forge:glass_panes']);
-
     // snad
     const compacted_sand = ['kubejs:compressed_sand', 'kubejs:double_compressed_sand', 'kubejs:compressed_red_sand', 'kubejs:double_compressed_red_sand'];
     event.add('minecraft:dead_bush_may_place_on', compacted_sand);


### PR DESCRIPTION
-Make black quartz craftable using the same recipes that ceu had
-Make enderio dark glass variants craftable using black quartz

-Fix the fast glass breaking code and move it to its own script since it made no sense to have it in unification
-Add clear glass, fused quartz, and glaxx to the glass breaking script