### PR TITLE
fix some tools not being able to get unbreaking from the enchantment table

### DIFF
--- a/kubejs/server_scripts/enchantments.js
+++ b/kubejs/server_scripts/enchantments.js
@@ -1,3 +1,4 @@
 MoreJSEvents.filterAvailableEnchantments((event) => {
 	event.remove("miniutilities:molten_head");
+	event.add("minecraft:unbreaking");
 })


### PR DESCRIPTION
Some gregtech tools don't get unbreaking from the enchantment table for some reason.
This one line fixes that.